### PR TITLE
Add Fortran implementation

### DIFF
--- a/fortran/Makefile
+++ b/fortran/Makefile
@@ -1,0 +1,23 @@
+F90 = gfortran  # compile with gfortran
+#
+MOD_DIR   = mod
+SRC_DIR   = src
+SRC_FILES = ${SRC_DIR}/cpf.o ${SRC_DIR}/profile.o
+PROGRAM   = test.o
+#
+TOTAL = $(SRC_FILES) $(PROGRAM)
+#
+CMPLFLG = -g -c -O3 -fdefault-real-8 -I${MOD_DIR}
+#
+.SUFFIXES: .f90 .o
+#
+all : $(TOTAL)
+	$(F90) $(TOTAL) -o test.x
+	rm -r *.o ${MOD_DIR} ${SRC_DIR}/*.o
+#
+clean:
+	rm -rf *.x *.o ${MOD_DIR} ${SRC_DIR}/*.o
+#
+%.o: %.f90
+	mkdir -p $(MOD_DIR)
+	$(F90) $(CMPLFLG) -J$(MOD_DIR) -c -o $@ $<

--- a/fortran/src/cpf.f90
+++ b/fortran/src/cpf.f90
@@ -1,0 +1,127 @@
+module cpf_module
+!----------------------------------------------------------------------!
+! This module provides 2 functions that compute complex probability
+! function (CPF):
+! 1. cpf_accurate - computes the CPF using rational series with 42 terms
+! 2. cpf_fast - computes the CPF using Humlicek's algorithm and rational
+!    series with 24 terms
+!----------------------------------------------------------------------!
+   use, intrinsic :: iso_fortran_env, only: int32, dp => real64
+   implicit none
+!----------------------------------------------------------------------!
+   contains
+!----------------------------------------------------------------------!
+   function cpf_accurate(x, y) result(cpf_z)
+      !----------------------------------------------------------------!
+      ! Computes the complex probability function using a rational
+      ! series with 42 terms. It is assumed that Im(z) > 0 or Im(z) = 0.
+      ! A series was simplified to 37 terms introducing less than
+      ! 10^(-17) deviations on mHT profile.
+      !
+      ! Input/Output Parameters of Routine
+      ! ---------------------------------------------------------------!
+      ! x : Real part of input complex parameter
+      ! y : Imaginary part of input complex parameter
+      !
+      ! The function provides one output:
+      ! ---------------------------------------------------------------!
+      ! (1): Complex probability function
+      !----------------------------------------------------------------!
+      real(dp), intent(in) :: x, y
+      complex(dp) :: cpf_z
+      !----------------------------------------------------------------!
+      integer(int32), parameter :: size_of_a = 37
+      real(dp), parameter :: another_parameter = 0.5641895835477563_dp
+      real(dp), parameter :: L = 5.449631621480024_dp
+      real(dp), dimension(size_of_a) :: a = (/-3.129493160727961e-14_dp,&
+         -1.188364999909099e-14_dp,  1.951777029849348e-13_dp,         &
+          1.790586243645278e-13_dp, -1.184560208678836e-12_dp,         &
+         -2.069163661083667e-12_dp,  6.430136110306704e-12_dp,         &
+          2.063579921011804e-11_dp, -2.392389527320517e-11_dp,         &
+         -1.799169607159564e-10_dp, -6.353807951660892e-11_dp,         &
+          1.282896083944607e-9_dp,   2.636162411919059e-09_dp,         &
+         -5.468780625369738e-9_dp,  -3.294773119114329e-8_dp,          &
+         -2.752070035718561e-8_dp,   2.206733163926054e-7_dp,          &
+          8.511689670641750e-7_dp,   4.936972061734341e-7_dp,          &
+         -6.617492208403963e-6_dp,  -2.914574364851397e-5_dp,          &
+         -4.816473680511106e-5_dp,   1.044072210002090e-4_dp,          &
+          1.070131083157417e-3_dp,   4.631075611097791e-3_dp,          &
+          1.480296368764821e-2_dp,   3.922970169744468e-2_dp,          &
+          9.038744880336540e-2_dp,   1.857036333535562e-1_dp,          &
+          3.455278077566057e-1_dp,   5.882708203344523e-1_dp,          &
+          9.230959991941070e-1_dp,   1.342044484596932_dp,             &
+          1.814714451499866_dp,      2.288734169675538_dp,             &
+          2.697763665856064_dp,      2.975931371735470_dp/)
+      !----------------------------------------------------------------!
+      complex(dp) :: z, z_ratio
+      integer(int32) :: i
+      !----------------------------------------------------------------!
+      z       = cmplx(-y, x, kind=dp)
+      z_ratio = (L + z) / (L - z)
+      cpf_z   = (0.0_dp, 0.0_dp)
+      do i = 1, size_of_a
+         cpf_z = cpf_z + a(i) * z_ratio**(real(size_of_a - i, kind = dp))
+      end do
+      cpf_z = 2.0_dp * cpf_z / (L - z)**2.0_dp + another_parameter / (L - z)
+      !----------------------------------------------------------------!
+   end function cpf_accurate
+!----------------------------------------------------------------------!
+   function cpf_fast(x, y) result(cpf_z)
+      !----------------------------------------------------------------!
+      ! Computes the complex probability function using Humlicek's 
+      ! algorithm in its first subregion (Source: 10.1016/0022-4073(82)90078-4) 
+      ! and using a rational series with 24 terms in other subregions.
+      !
+      ! Input/Output Parameters of Routine
+      ! ---------------------------------------------------------------!
+      ! x : Real part of input complex parameter
+      ! y : Imaginary part of input complex parameter
+      !
+      ! The function has one output:
+      ! ---------------------------------------------------------------!
+      ! (1): Complex probability function
+      ! ---------------------------------------------------------------!
+      real(dp), intent(in) :: x, y
+      complex(dp) :: cpf_z
+      ! ---------------------------------------------------------------!
+      integer(int32), parameter :: size_of_a = 24
+      real(dp), parameter :: another_parameter = 0.5641895835477563_dp
+      real(dp), parameter :: L = 4.119534287814236_dp
+      real, dimension(size_of_a) :: a = (/-1.513747622620502e-10_dp,   &
+          4.904820407381768e-9_dp,  1.331045329581992e-9_dp,           &
+         -3.008282344381996e-8_dp, -1.912225887484805e-8_dp,           &
+          1.873834346505099e-7_dp,  2.568264135399530e-7_dp,           &
+         -1.085647579417637e-6_dp, -3.038893184366094e-6_dp,           &
+          4.139461724429617e-6_dp,  3.047106608295325e-5_dp,           &
+          2.433141546207148e-5_dp, -2.074843151143828e-4_dp,           &
+         -7.816642995626165e-4_dp, -4.936426901286291e-4_dp,           &
+          6.215006362949147e-3_dp,  3.372336685531603e-2_dp,           &
+          1.083872348456673e-1_dp,  2.654963959880772e-1_dp,           &
+          5.361139535729116e-1_dp,  9.257087138588670e-1_dp,           &
+          1.394819673379119_dp,     1.856286499205540_dp,              &
+          2.197858936531542_dp/)
+      !----------------------------------------------------------------!
+      complex(dp) :: t, z, z_ratio
+      integer(int32) :: i
+      !----------------------------------------------------------------!
+      if (abs(x) + y < 15.0_dp) then
+         !-------------------------------------------------------------!
+         t = cmplx(y, -x, kind=dp)
+         cpf_z = another_parameter * t / (0.5_dp + t**2.0_dp)
+         !-------------------------------------------------------------!
+      else
+         !-------------------------------------------------------------!
+         z       = cmplx(-y, x, kind=dp)
+         z_ratio = (L + z) / (L - z)
+         cpf_z   = (0.0_dp, 0.0_dp)
+         do i = 1, size_of_a
+            cpf_z = cpf_z + a(i) * Z**(real(size_of_a - i, kind = dp))
+         end do
+         cpf_z = 2.0_dp * cpf_z / (L - z)**2.0_dp + another_parameter  &
+            / (L - z)
+         !-------------------------------------------------------------!
+      endif
+      !----------------------------------------------------------------!
+  end function cpf_fast
+!----------------------------------------------------------------------!
+end module cpf_module

--- a/fortran/src/profile.f90
+++ b/fortran/src/profile.f90
@@ -1,0 +1,180 @@
+module spectral_module
+!----------------------------------------------------------------------!
+! This module provides 2 functions 
+! 1. beta - computes the beta-correction used for the hard-collision
+!    based line-shape profiles
+! 2. profile - computes the modified Hartmann-Tran (mHT) profile
+!----------------------------------------------------------------------!
+   use, intrinsic :: iso_fortran_env, only: int32, dp => real64
+   use cpf_module, only: cpf_fast
+   implicit none
+!----------------------------------------------------------------------!
+   real(dp), parameter :: e  = 2.718281828459045_dp
+   real(dp), parameter :: pi = 3.141592653589793_dp
+   real(dp), parameter :: rp = 1.772453850905516_dp
+!----------------------------------------------------------------------!
+   contains
+!----------------------------------------------------------------------!
+   function beta(GamD, NuOptRe, alpha) result(beta_result)
+      !----------------------------------------------------------------!
+      ! "beta": Beta-Correction  
+      ! Subroutine to compute beta-correction used for hard-collision
+      ! based line-shape profiles to correct NuOptRe value.
+      ! Applicable up to alpha = 5.0; for higher alpha
+      ! values correction neglected. 
+      ! Source: 10.1016/j.jqsrt.2019.106784
+      !
+      ! Input/Output Parameters of Routine (Arguments or Common)
+      ! ---------------------------------------------------------------!
+      ! GamD      : Doppler HWHM in cm-1 (Input) 
+      ! NuOptRe   : Real part of the Dicke parameter in cm-1 (Input).
+      ! alpha     : Mass ratio in the molecule. Applicable up to alpha=5.
+      !
+      ! The function provides one output:
+      ! ---------------------------------------------------------------!
+      ! (1): Value of the beta correction 
+      !----------------------------------------------------------------!
+      real(dp), intent(in) :: GamD, NuOptRe, alpha
+      real(dp) :: beta_result
+      !----------------------------------------------------------------!
+      real(dp) :: a, b, c, d
+      !----------------------------------------------------------------!
+      if (alpha < 5.0_dp) then
+         !-------------------------------------------------------------!
+         a =  0.0534_dp + 0.1585_dp * exp(-0.4510_dp * alpha)
+         b =  1.9595_dp - 0.1258_dp * alpha + 0.0056_dp * alpha**2.0_dp&
+           + 0.0050_dp * alpha**3.0_dp
+         c = -0.0546_dp + 0.0672_dp * alpha - 0.0125_dp * alpha**2.0_dp&
+           + 0.0003_dp * alpha**3.0_dp
+         d =  0.9466_dp - 0.1585_dp * exp(-0.4510_dp * alpha)
+         beta_result = a * tanh(b * log10(0.5_dp * NuOptRe / GamD) + c)&
+           + d
+         !-------------------------------------------------------------!
+      else
+         !-------------------------------------------------------------!
+         beta_result = 1.0_dp
+         !-------------------------------------------------------------!
+      endif
+      !----------------------------------------------------------------!
+   end function beta
+!----------------------------------------------------------------------!
+   function profile(nu0,GamD,Gam0,Gam2,Shift0,Shift2,NuOptRe,NuOptIm,nu,&
+      Sw_opt,Ylm_opt,Xlm_opt,alpha_opt) result(mHT_profile)
+      !----------------------------------------------------------------!
+      ! "PROFILE_mHT": modified Hartman Tran profile
+      ! Subroutine to compute the complex normalized spectral shape of an 
+      ! isolated line by the mHT model
+      !
+      ! Input/Output Parameters of Routine (Arguments or Common)
+      ! ---------------------------------------------------------------!
+      ! nu0       : Unperturbed line position in cm-1 (Input).
+      ! GamD      : Doppler HWHM in cm-1 (Input)
+      ! Gam0      : Speed-averaged line-width in cm-1 (Input).       
+      ! Gam2      : Speed dependence of the line-width in cm-1 (Input).
+      ! Shift0    : Speed-averaged line-shift in cm-1 (Input).
+      ! Shift2    : Speed dependence of the line-shift in cm-1 (Input)   
+      ! NuOptRe   : Real part of the Dicke parameter in cm-1 (Input).
+      ! NuOptIm   : Imaginary part of the Dicke parameter in cm-1 (Input).    
+      ! nu        : Current WaveNumber of the Computation in cm-1 (Input).
+      ! Sw  		: Statistical weight 
+      ! Ylm       : Imaginary part of the 1st order (Rosenkranz) line
+      !             mixing coefficients in cm-1 (Input)
+      ! Xlm       : Real part of the 1st order (Rosenkranz) line mixing
+      !             coefficients in cm-1 (Input)
+      ! alpha     : Mass ratio in the molecule for calculating
+      !             beta-correction. Applicable up to alpha=5.
+      !
+      ! The function provides one, complex output:
+      ! ---------------------------------------------------------------!
+      ! (1) the normalized spectral shape (cm)
+      !----------------------------------------------------------------!
+      real(dp), intent(in) :: nu0, GamD, Gam0, Gam2, Shift0, Shift2,   &
+         NuOptRe, NuOptIm, nu
+      real(dp), intent(in), optional :: Sw_opt, Ylm_opt, Xlm_opt,      &
+         alpha_opt
+      complex(dp) :: mHT_profile
+      !----------------------------------------------------------------!
+      real(dp), parameter :: a_constant = 0.8325546111576977_dp
+      real(dp), parameter :: zero_tolerance  = 1e-15_dp
+      real(dp), parameter :: small_threshold = 3e-8_dp
+      real(dp), parameter :: big_threshold = 4e3_dp
+      !----------------------------------------------------------------!
+      real(dp) :: Sw, Ylm, Xlm, alpha
+      real(dp) :: nuD, nuR
+      complex(dp) :: c2, c0, LM, X, Y, csqY, z1, z2, w1, w2, wX, A,    &
+         X_sqrt, z, w
+      !----------------------------------------------------------------!
+      if (present(Sw_opt)) then
+         Sw = Sw_opt
+      else
+         Sw = 1.0_dp
+      endif 
+      !----------------------------------------------------------------!
+      if (present(Ylm_opt)) then
+         Ylm = Ylm_opt
+      else
+         Ylm = 0.0_dp
+      endif
+      !----------------------------------------------------------------!
+      if (present(Xlm_opt)) then
+         Xlm = Xlm_opt
+      else
+         Xlm = 0.0_dp
+      endif 
+      !----------------------------------------------------------------!
+      if (present(alpha_opt)) then
+         alpha = alpha_opt
+      else
+         alpha = 10.0_dp
+      endif 
+      !----------------------------------------------------------------!
+      nuD = GamD / a_constant
+      nuR = NuOptRe*beta(GamD,NuOptRe,alpha)
+      c2  = cmplx(Gam2, Shift2, kind=dp)
+      c0  = cmplx(Gam0, Shift0, kind=dp) - 1.5_dp*c2 + nuR             &
+          + cmplx(0.0_dp, NuOptIm, kind=dp)
+      LM  = cmplx(1.0_dp + Xlm, Ylm, kind=dp)
+      !----------------------------------------------------------------!
+      if ( abs(c2) > zero_tolerance ) then
+         !-------------------------------------------------------------!
+         X    = (cmplx(0_dp, nu0-nu, kind=dp) + c0) / c2
+         Y    = 0.25_dp*(nuD/c2)**2.0_dp
+         csqY = 0.5_dp*nuD*cmplx(Gam2, -Shift2, kind=dp)               &
+              /(Gam2**2.0_dp + Shift2**2.0_dp)
+         if ( abs( Y )  > abs( X  ) * zero_tolerance ) then
+            !----------------------------------------------------------!
+            z2 = (X+Y)**0.5_dp + csqY
+            if  ( abs(X)  > abs(Y)  * small_threshold ) then
+               z1 = z2 - 2.0_dp * csqY
+            else
+               z1 = (cmplx(0.0_dp, nu0-nu, kind=dp) + c0) / nuD    
+            endif
+            w1 = cpf_fast(-aimag(z1),real(z1))
+            w2 = cpf_fast(-aimag(z2),real(z2))
+            A  = rp/nuD*(w1-w2)
+            !----------------------------------------------------------!
+         else
+            !----------------------------------------------------------!
+            X_sqrt = (X)**0.5_dp
+            if (  abs(X) < big_threshold ) then
+               wX = cpf_fast(-aimag(X_sqrt),real(X_sqrt))
+               A  = 2.0_dp*(1.0_dp - rp*X_sqrt*wX)/c2
+            else
+               A  = (1.0_dp/X - 1.5_dp/X**2.0_dp)/c2
+            endif
+            !----------------------------------------------------------!
+         endif
+         !-------------------------------------------------------------!
+      else
+         !-------------------------------------------------------------!
+         z = (cmplx(0.0_dp, nu0-nu, kind=dp) + c0) / nuD
+         w = cpf_fast(-aimag(z),real(z))
+         A = w*rp/nuD
+         !-------------------------------------------------------------!
+      endif
+      
+      mHT_profile = Sw*LM/pi*A/(1-(nuR + cmplx(0.0_dp, NuOptIm, kind=dp))*A)
+
+   end function profile 
+
+end module spectral_module

--- a/fortran/test.f90
+++ b/fortran/test.f90
@@ -1,0 +1,37 @@
+program test_mHT
+!----------------------------------------------------------------------!
+! This simple program tests the subroutines computing the modified
+! Hartmann-Tran (mHT) profile for a set of default line-shape parameters
+!----------------------------------------------------------------------!
+   use, intrinsic :: iso_fortran_env, only: int32, dp => real64
+   use spectral_module
+!----------------------------------------------------------------------!
+   implicit none
+!----------------------------------------------------------------------!
+   complex(dp) :: mHT
+      ! Spectral line shape function (in cm)
+   real(dp) :: nu0     = 0.0_dp
+      ! Central frequency of the transition (in cm^(-1))
+   real(dp) :: GamD    = 1.0_dp
+      ! The Doppler width (in cm^(-1))
+   real(dp) :: Gam0    = 1.0_dp
+      ! The speed-averaged pressure broadening coefficient (in cm^(-1))
+   real(dp) :: Gam2    = 0.1_dp
+      ! The quadratic speed-dependence coefficient for pressure broadening
+      ! (in cm^(-1))
+   real(dp) :: Shift0  = 1.0_dp
+      ! The speed-averaged pressure shift coefficient (in cm^(-1))
+   real(dp) :: Shift2  = 0.1_dp
+      ! The quadratic speed-dependence coefficient for pressure broadening
+      ! (in cm^(-1))
+   real(dp) :: NuOptRe = 0.1_dp
+      ! Real part of the complex Dicke parameter (in cm^(-1))
+   real(dp) :: NuOptIm = 0.01_dp
+      ! Imaginary part of the complex Dicke parameter (in cm^(-1))
+   real(dp) :: nu      = 0.0_dp
+      ! Frequency (in cm^(-1))
+!----------------------------------------------------------------------!
+   mHT = profile(nu0,GamD,Gam0,Gam2,Shift0,Shift2,NuOptRe,NuOptIm,nu)
+   print *, "mHT test: ", mHT
+!----------------------------------------------------------------------!
+end program test_mHT


### PR DESCRIPTION
Fortran implementation based on two modules, similar to the Python case:
- cpf_module (implementation of `cpf_fast` and `cpf_accurate`),
- spectral_module (implementation of `beta` and `profile`).
 
No external libraries are needed. The `test` program uses gfortran.