### PR TITLE
Add fortran77 subroutines and example programs

### DIFF
--- a/fortran/example_absorption.f90
+++ b/fortran/example_absorption.f90
@@ -1,18 +1,18 @@
 program example_absorption
 
-! example parameters of the S(1) 3-0 line of H2 perturbed by Ar (reference 10.1063/5.0139229)
+! Example parameters of the S(1) 3-0 line of H2 perturbed by He (reference: 10.1103/PhysRevA.101.052705)
    use, intrinsic :: iso_fortran_env, only: int32, dp => real64
    use spectral_module, only: profile
    implicit none
    real(dp) :: mHT
    real(dp) :: nu0 = 112265.5949_dp ! Unperturbed line position in cm-1.
    real(dp) :: GammaD = 35.1e-3_dp ! Doppler broadening in cm-1.
-   real(dp) :: Gamma0 = 11.3e-3_dp ! Speed-averaged line-width in cm-1.
-   real(dp) :: Gamma2 = 0.374e-3_dp ! Speed dependence of the line-width in cm-1.
-   real(dp) :: Delta0 = -26.4e-3_dp ! Speed-averaged line-shift in cm-1.
-   real(dp) :: Delta2 = 17.8e-3_dp ! Speed dependence of the line-shift in cm-1.
-   real(dp) :: NuOptRe = 72.1e-3_dp ! Real part of the Dicke parameter in cm-1.
-   real(dp) :: NuOptIm = -16.1e-3_dp ! Imaginary part of the Dicke parameter in cm-1.
+   real(dp) :: Gamma0 = 11.7e-3_dp ! Speed-averaged line-width in cm-1.
+   real(dp) :: Gamma2 = 5.4e-3_dp ! Speed dependence of the line-width in cm-1.
+   real(dp) :: Delta0 = 30.5e-3_dp ! Speed-averaged line-shift in cm-1.
+   real(dp) :: Delta2 = 12.4e-3_dp ! Speed dependence of the line-shift in cm-1.
+   real(dp) :: NuOptRe = 38.0e-3_dp ! Real part of the Dicke parameter in cm-1.
+   real(dp) :: NuOptIm = -17.5e-3_dp ! Imaginary part of the Dicke parameter in cm-1.
    real(dp) :: nu ! Current wavenumber of the computation in cm-1.
    nu  = nu0 + 1.0_dp
    mHT = profile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,NuOptRe,NuOptIm,nu)

--- a/fortran/example_dispersion.f90
+++ b/fortran/example_dispersion.f90
@@ -1,18 +1,18 @@
 program example_absorption
 
-! example parameters of the S(1) 3-0 line of H2 perturbed by Ar (reference 10.1063/5.0139229)
+! Example parameters of the S(1) 3-0 line of H2 perturbed by He (reference: 10.1103/PhysRevA.101.052705)
    use, intrinsic :: iso_fortran_env, only: int32, dp => real64
    use spectral_module, only: profile
    implicit none
    real(dp) :: mHT
    real(dp) :: nu0 = 112265.5949_dp ! Unperturbed line position in cm-1.
    real(dp) :: GammaD = 35.1e-3_dp ! Doppler broadening in cm-1.
-   real(dp) :: Gamma0 = 11.3e-3_dp ! Speed-averaged line-width in cm-1.
-   real(dp) :: Gamma2 = 0.374e-3_dp ! Speed dependence of the line-width in cm-1.
-   real(dp) :: Delta0 = -26.4e-3_dp ! Speed-averaged line-shift in cm-1.
-   real(dp) :: Delta2 = 17.8e-3_dp ! Speed dependence of the line-shift in cm-1.
-   real(dp) :: NuOptRe = 72.1e-3_dp ! Real part of the Dicke parameter in cm-1.
-   real(dp) :: NuOptIm = -16.1e-3_dp ! Imaginary part of the Dicke parameter in cm-1.
+   real(dp) :: Gamma0 = 11.7e-3_dp ! Speed-averaged line-width in cm-1.
+   real(dp) :: Gamma2 = 5.4e-3_dp ! Speed dependence of the line-width in cm-1.
+   real(dp) :: Delta0 = 30.5e-3_dp ! Speed-averaged line-shift in cm-1.
+   real(dp) :: Delta2 = 12.4e-3_dp ! Speed dependence of the line-shift in cm-1.
+   real(dp) :: NuOptRe = 38.0e-3_dp ! Real part of the Dicke parameter in cm-1.
+   real(dp) :: NuOptIm = -17.5e-3_dp ! Imaginary part of the Dicke parameter in cm-1.
    real(dp) :: nu ! Current wavenumber of the computation in cm-1.
    logical :: calculate_dispersion = .true. ! The mHT function will return the dispersion profile.
    nu  = nu0 + 1.0_dp

--- a/fortran/example_mHT_optional_parameters.f90
+++ b/fortran/example_mHT_optional_parameters.f90
@@ -3,15 +3,15 @@ program example_mHT_optional_parameters
    use spectral_module, only: profile
    implicit none
    real(dp) :: absorption, dispersion
-! example parameters of the S(1) 3-0 line of H2 perturbed by Ar (reference 10.1063/5.0139229)
+! Example parameters of the S(1) 3-0 line of H2 perturbed by He (reference: 10.1103/PhysRevA.101.052705)
    real(dp) :: nu0 = 112265.5949_dp ! Unperturbed line position in cm-1.
    real(dp) :: GammaD = 35.1e-3_dp ! Doppler broadening in cm-1.
-   real(dp) :: Gamma0 = 11.3e-3_dp ! Speed-averaged line-width in cm-1.
-   real(dp) :: Gamma2 = 0.374e-3_dp ! Speed dependence of the line-width in cm-1.
-   real(dp) :: Delta0 = -26.4e-3_dp ! Speed-averaged line-Delta in cm-1.
-   real(dp) :: Delta2 = 17.8e-3_dp ! Speed dependence of the line-shift in cm-1.
-   real(dp) :: NuOptRe = 72.1e-3_dp ! Real part of the Dicke parameter in cm-1.
-   real(dp) :: NuOptIm = -16.1e-3_dp ! Imaginary part of the Dicke parameter in cm-1.
+   real(dp) :: Gamma0 = 11.7e-3_dp ! Speed-averaged line-width in cm-1.
+   real(dp) :: Gamma2 = 5.4e-3_dp ! Speed dependence of the line-width in cm-1.
+   real(dp) :: Delta0 = 30.5e-3_dp ! Speed-averaged line-shift in cm-1.
+   real(dp) :: Delta2 = 12.4e-3_dp ! Speed dependence of the line-shift in cm-1.
+   real(dp) :: NuOptRe = 38.0e-3_dp ! Real part of the Dicke parameter in cm-1.
+   real(dp) :: NuOptIm = -17.5e-3_dp ! Imaginary part of the Dicke parameter in cm-1.
    real(dp) :: nu ! Current wavenumber of the computation in cm-1.
    real(dp) :: Ylm ! Real part of the 1st order (Rosenkranz) line mixing coefficients, dimensionless.
    real(dp) :: Xlm ! Imaginary part of the 1st order (Rosenkranz) line mixing coefficients, dimensionless.

--- a/fortran77/Makefile
+++ b/fortran77/Makefile
@@ -1,0 +1,49 @@
+F90 = gfortran  # compile with gfortran
+
+SRC_DIR   = src
+SRC_FILES = ${SRC_DIR}/cpf.o ${SRC_DIR}/profile.o
+
+# List of usage examples:
+ABSORPTION_OBJ = example_absorption.o
+DISPERSION_OBJ = example_dispersion.o
+CPF_OBJ = example_cpf.o
+OPTIONAL_PARAMETERS_OBJ = example_mHT_optional_parameters.o
+PROFILES_OBJ = example_profiles.o
+
+ABSORPTION = $(SRC_FILES) $(ABSORPTION_OBJ)
+DISPERSION = $(SRC_FILES) $(DISPERSION_OBJ)
+CPF = $(SRC_FILES) $(CPF_OBJ)
+OPTIONAL_PARAMETERS = $(SRC_FILES) $(OPTIONAL_PARAMETERS_OBJ)
+PROFILES = $(SRC_FILES) $(PROFILES_OBJ)
+
+CMPLFLG = -g -c -O3 -fdefault-real-8 -I${SRC_DIR}
+
+.SUFFIXES: .f .o
+
+.PHONY: cpf
+
+all: absorption dispersion cpf optional_parameters profiles clean
+
+absorption: $(ABSORPTION)
+	$(F90) $(ABSORPTION) -o example_absorption.x
+
+dispersion: $(DISPERSION)
+	$(F90) $(DISPERSION) -o example_dispersion.x
+
+cpf: $(CPF)
+	$(F90) $(CPF) -o example_cpf.x
+
+optional_parameters: $(OPTIONAL_PARAMETERS)
+	$(F90) $(OPTIONAL_PARAMETERS) -o example_mHT_optional_parameters.x
+
+profiles: $(PROFILES)
+	$(F90) $(PROFILES) -o example_profiles.x
+
+clean:
+	rm -rf *.o ${SRC_DIR}/*.o
+
+remove_executables:
+	rm -rf *.x
+
+%.o: %.f
+	$(F90) $(CMPLFLG) -c -o $@ $<

--- a/fortran77/example_absorption.f
+++ b/fortran77/example_absorption.f
@@ -1,15 +1,15 @@
       program example_absorption
-c example parameters of the S(1) 3-0 line of H2 perturbed by Ar (reference 10.1063/5.0139229)
+c Example parameters of the S(1) 3-0 line of H2 perturbed by He (reference: 10.1103/PhysRevA.101.052705)
       implicit none
       real*8 :: mHT, profile
       real*8 :: nu0 = 112265.5949d0 ! Unperturbed line position in cm-1.
       real*8 :: GammaD = 35.1d-3 ! Doppler broadening in cm-1.
-      real*8 :: Gamma0 = 11.3d-3 ! Speed-averaged line-width in cm-1.
-      real*8 :: Gamma2 = 0.374d-3 ! Speed dependence of the line-width in cm-1.
-      real*8 :: Delta0 = -26.4d-3 ! Speed-averaged line-shift in cm-1.
-      real*8 :: Delta2 = 17.8d-3 ! Speed dependence of the line-shift in cm-1.
-      real*8 :: NuOptRe = 72.1d-3 ! Real part of the Dicke parameter in cm-1.
-      real*8 :: NuOptIm = -16.1d-3 ! Imaginary part of the Dicke parameter in cm-1.
+      real*8 :: Gamma0 = 11.7d-3 ! Speed-averaged line-width in cm-1.
+      real*8 :: Gamma2 = 5.4d-3 ! Speed dependence of the line-width in cm-1.
+      real*8 :: Delta0 = 30.5d-3 ! Speed-averaged line-shift in cm-1.
+      real*8 :: Delta2 = 12.4d-3 ! Speed dependence of the line-shift in cm-1.
+      real*8 :: NuOptRe = 38.0d-3 ! Real part of the Dicke parameter in cm-1.
+      real*8 :: NuOptIm = -17.7d-3 ! Imaginary part of the Dicke parameter in cm-1.
       real*8 :: nu ! Current wavenumber of the computation in cm-1.
       real*8 :: Ylm = 0d0 ! Imaginary part of the 1st order (Rosenkranz) line mixing coefficients
       real*8 :: Xlm = 0d0 ! Real part of the 1st order (Rosenkranz) line mixing coefficients

--- a/fortran77/example_absorption.f
+++ b/fortran77/example_absorption.f
@@ -1,0 +1,26 @@
+      program example_absorption
+c example parameters of the S(1) 3-0 line of H2 perturbed by Ar (reference 10.1063/5.0139229)
+      implicit none
+      real*8 :: mHT, profile
+      real*8 :: nu0 = 112265.5949d0 ! Unperturbed line position in cm-1.
+      real*8 :: GammaD = 35.1d-3 ! Doppler broadening in cm-1.
+      real*8 :: Gamma0 = 11.3d-3 ! Speed-averaged line-width in cm-1.
+      real*8 :: Gamma2 = 0.374d-3 ! Speed dependence of the line-width in cm-1.
+      real*8 :: Delta0 = -26.4d-3 ! Speed-averaged line-shift in cm-1.
+      real*8 :: Delta2 = 17.8d-3 ! Speed dependence of the line-shift in cm-1.
+      real*8 :: NuOptRe = 72.1d-3 ! Real part of the Dicke parameter in cm-1.
+      real*8 :: NuOptIm = -16.1d-3 ! Imaginary part of the Dicke parameter in cm-1.
+      real*8 :: nu ! Current wavenumber of the computation in cm-1.
+      real*8 :: Ylm = 0d0 ! Imaginary part of the 1st order (Rosenkranz) line mixing coefficients
+      real*8 :: Xlm = 0d0 ! Real part of the 1st order (Rosenkranz) line mixing coefficients
+      real*8 :: alpha = 10d0 ! perturber-to-absorber mass ratio
+      logical :: calculate_dispersion=.false. ! Only the absorption profile will be calculated
+
+      nu  = nu0 + 1.0d0
+      mHT = profile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,NuOptRe,
+     &              NuOptIm,nu,Ylm,Xlm,alpha,calculate_dispersion)
+   
+      write(*,101) mHT
+ 101  format('The output of the mHT function (absorption, Ar-perturbed',
+     &   ' S(1) 3-0 line in H2):', F22.15)
+      end program example_absorption

--- a/fortran77/example_cpf.f
+++ b/fortran77/example_cpf.f
@@ -1,0 +1,28 @@
+      program example_cpf
+      implicit none
+      include 'constants.inc'
+      
+      ! Declare variables
+      real*8 cpf_input_real, cpf_input_imag
+      complex*16 cpf_accurate, cpf_fast
+      complex*16 cpf_accurate_output, cpf_fast_output
+
+      ! Initialize example parameters for the CPF functions
+      cpf_input_real = 1.0d0  ! dimensionless
+      cpf_input_imag = 1.0d0  ! dimensionless
+
+      ! Call cpf_accurate
+      cpf_accurate_output = cpf_accurate(cpf_input_real, cpf_input_imag)
+
+      ! Call cpf_fast
+      cpf_fast_output = cpf_fast(cpf_input_real, cpf_input_imag)
+
+      ! Output results
+      write(*, '(A)') 'the output of the cpf_accurate function: '
+      write(*, '(2F22.15)') real(cpf_accurate_output),
+     &                        imag(cpf_accurate_output)
+
+      write(*, '(A)') 'the output of the cpf_fast function:     '
+      write(*, '(2F22.15)') real(cpf_fast_output), imag(cpf_fast_output)
+
+      end program example_cpf

--- a/fortran77/example_dispersion.f
+++ b/fortran77/example_dispersion.f
@@ -4,12 +4,12 @@ c example parameters of the S(1) 3-0 line of H2 perturbed by Ar (reference 10.10
       real*8 :: mHT, profile
       real*8 :: nu0 = 112265.5949d0 ! Unperturbed line position in cm-1.
       real*8 :: GammaD = 35.1d-3 ! Doppler broadening in cm-1.
-      real*8 :: Gamma0 = 11.3d-3 ! Speed-averaged line-width in cm-1.
-      real*8 :: Gamma2 = 0.374d-3 ! Speed dependence of the line-width in cm-1.
-      real*8 :: Delta0 = -26.4d-3 ! Speed-averaged line-shift in cm-1.
-      real*8 :: Delta2 = 17.8d-3 ! Speed dependence of the line-shift in cm-1.
-      real*8 :: NuOptRe = 72.1d-3 ! Real part of the Dicke parameter in cm-1.
-      real*8 :: NuOptIm = -16.1d-3 ! Imaginary part of the Dicke parameter in cm-1.
+      real*8 :: Gamma0 = 11.7d-3 ! Speed-averaged line-width in cm-1.
+      real*8 :: Gamma2 = 5.4d-3 ! Speed dependence of the line-width in cm-1.
+      real*8 :: Delta0 = 30.5d-3 ! Speed-averaged line-shift in cm-1.
+      real*8 :: Delta2 = 12.4d-3 ! Speed dependence of the line-shift in cm-1.
+      real*8 :: NuOptRe = 38.0d-3 ! Real part of the Dicke parameter in cm-1.
+      real*8 :: NuOptIm = -17.7d-3 ! Imaginary part of the Dicke parameter in cm-1.
       real*8 :: nu ! Current wavenumber of the computation in cm-1.
       real*8 :: Ylm = 0d0 ! Imaginary part of the 1st order (Rosenkranz) line mixing coefficients
       real*8 :: Xlm = 0d0 ! Real part of the 1st order (Rosenkranz) line mixing coefficients

--- a/fortran77/example_dispersion.f
+++ b/fortran77/example_dispersion.f
@@ -1,5 +1,5 @@
       program example_dispersion
-c example parameters of the S(1) 3-0 line of H2 perturbed by Ar (reference 10.1063/5.0139229)
+c Example parameters of the S(1) 3-0 line of H2 perturbed by He (reference: 10.1103/PhysRevA.101.052705)
       implicit none
       real*8 :: mHT, profile
       real*8 :: nu0 = 112265.5949d0 ! Unperturbed line position in cm-1.

--- a/fortran77/example_dispersion.f
+++ b/fortran77/example_dispersion.f
@@ -1,0 +1,26 @@
+      program example_dispersion
+c example parameters of the S(1) 3-0 line of H2 perturbed by Ar (reference 10.1063/5.0139229)
+      implicit none
+      real*8 :: mHT, profile
+      real*8 :: nu0 = 112265.5949d0 ! Unperturbed line position in cm-1.
+      real*8 :: GammaD = 35.1d-3 ! Doppler broadening in cm-1.
+      real*8 :: Gamma0 = 11.3d-3 ! Speed-averaged line-width in cm-1.
+      real*8 :: Gamma2 = 0.374d-3 ! Speed dependence of the line-width in cm-1.
+      real*8 :: Delta0 = -26.4d-3 ! Speed-averaged line-shift in cm-1.
+      real*8 :: Delta2 = 17.8d-3 ! Speed dependence of the line-shift in cm-1.
+      real*8 :: NuOptRe = 72.1d-3 ! Real part of the Dicke parameter in cm-1.
+      real*8 :: NuOptIm = -16.1d-3 ! Imaginary part of the Dicke parameter in cm-1.
+      real*8 :: nu ! Current wavenumber of the computation in cm-1.
+      real*8 :: Ylm = 0d0 ! Imaginary part of the 1st order (Rosenkranz) line mixing coefficients
+      real*8 :: Xlm = 0d0 ! Real part of the 1st order (Rosenkranz) line mixing coefficients
+      real*8 :: alpha = 10d0 ! perturber-to-absorber mass ratio
+      logical :: calculate_dispersion = .true. ! The mHT function will return the dispersion profile.
+
+      nu  = nu0 + 1.0d0
+      mHT = profile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,NuOptRe,
+     &      NuOptIm,nu,Ylm,Xlm,alpha,calculate_dispersion)
+   
+      write(*,101) mHT
+ 101  format('The output of the mHT function (dispersion, Ar-perturbed',
+     &   ' S(1) 3-0 line in H2):', F22.15)
+      end program example_dispersion

--- a/fortran77/example_mHT_optional_parameters.f
+++ b/fortran77/example_mHT_optional_parameters.f
@@ -1,0 +1,45 @@
+      program example_mHT_optional_parameters
+c example parameters of the S(1) 3-0 line of H2 perturbed by Ar (reference 10.1063/5.0139229)
+      implicit none
+      real*8 :: absorption, dispersion, profile
+      real*8 :: nu0 = 112265.5949d0 ! Unperturbed line position in cm-1.
+      real*8 :: GammaD = 35.1d-3 ! Doppler broadening in cm-1.
+      real*8 :: Gamma0 = 11.3d-3 ! Speed-averaged line-width in cm-1.
+      real*8 :: Gamma2 = 0.374d-3 ! Speed dependence of the line-width in cm-1.
+      real*8 :: Delta0 = -26.4d-3 ! Speed-averaged line-Delta in cm-1.
+      real*8 :: Delta2 = 17.8d-3 ! Speed dependence of the line-shift in cm-1.
+      real*8 :: NuOptRe = 72.1d-3 ! Real part of the Dicke parameter in cm-1.
+      real*8 :: NuOptIm = -16.1d-3 ! Imaginary part of the Dicke parameter in cm-1.
+      real*8 :: nu ! Current wavenumber of the computation in cm-1.
+      real*8 :: Ylm = 0d0 ! Imaginary part of the 1st order (Rosenkranz) line mixing coefficients
+      real*8 :: Xlm = 0d0 ! Real part of the 1st order (Rosenkranz) line mixing coefficients
+      real*8 :: alpha = 10d0 ! perturber-to-absorber mass ratio
+      logical :: calculate_dispersion=.false. ! Only the absorption profile will be calculated
+   
+      nu  = nu0 + 1d0
+      absorption = profile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,
+     &            NuOptRe,NuOptIm,nu,Ylm,Xlm,alpha,calculate_dispersion)
+      calculate_dispersion = .true.
+      dispersion = profile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,
+     &            NuOptRe,NuOptIm,nu,Ylm,Xlm,alpha,calculate_dispersion)
+      write(*, 101) absorption, dispersion
+ 101  format('The output of the mHT function (Ar-perturbed S(1)',
+     &       ' 3-0 line in H2):',25X, 2F22.15)
+c optional parameters
+      Ylm = 1.0d-3
+      Xlm = 0.5d-3
+      alpha = 20.0d0
+      calculate_dispersion = .false.
+      
+      absorption = profile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,
+     &            NuOptRe,NuOptIm,nu,Ylm,Xlm,alpha,calculate_dispersion)
+     
+      calculate_dispersion = .true.
+      dispersion = profile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,
+     &            NuOptRe,NuOptIm,nu,Ylm,Xlm,alpha,calculate_dispersion)
+
+      write(*, 102) absorption, dispersion
+ 102  format('The output of the mHT function with optional parameters ',
+     &       '(Ar-perturbed S(1) 3-0 line in H2):', 2F22.15)
+
+      end program example_mHT_optional_parameters

--- a/fortran77/example_mHT_optional_parameters.f
+++ b/fortran77/example_mHT_optional_parameters.f
@@ -1,15 +1,15 @@
       program example_mHT_optional_parameters
-c example parameters of the S(1) 3-0 line of H2 perturbed by Ar (reference 10.1063/5.0139229)
+c Example parameters of the S(1) 3-0 line of H2 perturbed by He (reference: 10.1103/PhysRevA.101.052705)
       implicit none
-      real*8 :: absorption, dispersion, profile
+      real*8 :: mHT, profile
       real*8 :: nu0 = 112265.5949d0 ! Unperturbed line position in cm-1.
       real*8 :: GammaD = 35.1d-3 ! Doppler broadening in cm-1.
-      real*8 :: Gamma0 = 11.3d-3 ! Speed-averaged line-width in cm-1.
-      real*8 :: Gamma2 = 0.374d-3 ! Speed dependence of the line-width in cm-1.
-      real*8 :: Delta0 = -26.4d-3 ! Speed-averaged line-Delta in cm-1.
-      real*8 :: Delta2 = 17.8d-3 ! Speed dependence of the line-shift in cm-1.
-      real*8 :: NuOptRe = 72.1d-3 ! Real part of the Dicke parameter in cm-1.
-      real*8 :: NuOptIm = -16.1d-3 ! Imaginary part of the Dicke parameter in cm-1.
+      real*8 :: Gamma0 = 11.7d-3 ! Speed-averaged line-width in cm-1.
+      real*8 :: Gamma2 = 5.4d-3 ! Speed dependence of the line-width in cm-1.
+      real*8 :: Delta0 = 30.5d-3 ! Speed-averaged line-shift in cm-1.
+      real*8 :: Delta2 = 12.4d-3 ! Speed dependence of the line-shift in cm-1.
+      real*8 :: NuOptRe = 38.0d-3 ! Real part of the Dicke parameter in cm-1.
+      real*8 :: NuOptIm = -17.7d-3 ! Imaginary part of the Dicke parameter in cm-1.
       real*8 :: nu ! Current wavenumber of the computation in cm-1.
       real*8 :: Ylm = 0d0 ! Imaginary part of the 1st order (Rosenkranz) line mixing coefficients
       real*8 :: Xlm = 0d0 ! Real part of the 1st order (Rosenkranz) line mixing coefficients

--- a/fortran77/example_profiles.f
+++ b/fortran77/example_profiles.f
@@ -1,0 +1,105 @@
+      program example_profiles
+      implicit none
+      integer, parameter :: number_of_points = 1001 ! Number of points on the frequency grid
+      real*8 :: nu_tabulated(number_of_points) ! Frequency grid in cm-1.
+      real*8 :: absorption_tabulated(number_of_points),
+     &          dispersion_tabulated(number_of_points)
+      real*8 :: profile
+      real*8 :: nu0 ! Unperturbed line position in cm-1.
+      real*8 :: GammaD ! Doppler broadening in cm-1.
+      real*8 :: Gamma0_He, Gamma0_Ar ! Speed-averaged line-width in cm-1.
+      real*8 :: Gamma2_He, Gamma2_Ar ! Speed dependence of the line-width in cm-1.
+      real*8 :: Delta0_He, Delta0_Ar ! Speed-averaged line-shift in cm-1.
+      real*8 :: Delta2_He, Delta2_Ar ! Speed dependence of the line-shift in cm-1.
+      real*8 :: NuOptRe_He, NuOptRe_Ar ! Real part of the Dicke parameter in cm-1.
+      real*8 :: NuOptIm_He, NuOptIm_Ar ! Imaginary part of the Dicke parameter in cm-1.
+      real*8 :: Ylm ! Real part of the 1st order (Rosenkranz) line mixing coefficients, dimensionless.
+      real*8 :: Xlm ! Imaginary part of the 1st order (Rosenkranz) line mixing coefficients, dimensionless.
+      real*8 :: alpha_He, alpha_Ar ! perturber-to-absorber mass ratio, dimensionless.
+      logical :: calculate_dispersion, not_calculate_dispersion ! The mHT function will return either the dispersion or absorption profile.
+
+      integer :: unit_ = 10 ! File unit number (fixed at 10)
+      integer :: point ! A running index for iteration
+      real*8  :: nu_step ! Frequency step (in cm^(-1))
+   
+c example parameters of the S(1) 3-0 line of H2 perturbed by Ar (reference 10.1063/5.0139229)
+      nu0        = 112265.5949d0
+      GammaD     = 35.1d-3
+      Gamma0_Ar  = 11.3d-3
+      Gamma2_Ar  = 0.374d-3
+      Delta0_Ar  =-26.4d-3
+      Delta2_Ar  = 17.8d-3
+      NuOptRe_Ar = 72.1d-3
+      NuOptIm_Ar =-16.1d-3
+      Ylm        = 1.0d-3
+      Xlm        = 0.5d-3
+      alpha_Ar   = 20d0
+      calculate_dispersion = .true.
+      not_calculate_dispersion = .false.
+
+c Generate the mHT profile from -5 GammaD to +5 GammaD and save to an external file
+      write(*,101)
+ 101  format('Generating the mHT profile for the Ar-perturbed',
+     &       ' 3-0 S(1) line in H2...')
+      nu_step = (10*GammaD) / dfloat(number_of_points - 1)
+
+      open(unit=unit_, file='mHT_profile_H2Ar.txt', status='replace',
+     &     action='write')
+
+      write(unit_, '(A11,9X,A9,13X,A9)') '# Frequency', 'Real(mHT)',
+     &     'Imag(mHT)'
+   
+      do point = 1, number_of_points
+         nu_tabulated(point) = nu0 - 5*GammaD + (point-1) * nu_step
+         absorption_tabulated(point) = profile(nu0,GammaD,Gamma0_Ar,
+     &      Gamma2_Ar,Delta0_Ar,Delta2_Ar,NuOptRe_Ar,NuOptIm_Ar,
+     &      nu_tabulated(point),Ylm,Xlm,alpha_Ar,
+     &      not_calculate_dispersion)
+         dispersion_tabulated(point) = profile(nu0,GammaD,Gamma0_Ar,
+     &      Gamma2_Ar,Delta0_Ar,Delta2_Ar,NuOptRe_Ar,NuOptIm_Ar,
+     &      nu_tabulated(point),Ylm,Xlm,alpha_Ar,calculate_dispersion)
+
+      write(unit_, '(F15.8, 2F22.15)') nu_tabulated(point),
+     &   absorption_tabulated(point), dispersion_tabulated(point)
+
+      end do
+
+      close(unit_)
+      write(*,102)
+ 102  format('The result has been saved to mHT_profile_H2Ar.txt')
+   
+c example parameters of the S(1) 3-0 line of H2 perturbed by He (reference 10.1103/PhysRevA.101.052705)
+      write(*,103)
+ 103  format('Generating the mHT profile for the He-perturbed 3-0 S(1)', 
+     &       ' line in H2...')
+      Gamma0_He  = 11.7d-3
+      Gamma2_He  = 5.4d-3
+      Delta0_He  = 30.5d-3
+      Delta2_He  = 12.4d-3
+      NuOptRe_He = 38.0d-3
+      NuOptIm_He =-17.5d-3
+      alpha_He = 2d0
+
+      open(unit=unit_, file='mHT_profile_H2He.txt', status='replace',
+     &     action='write')
+
+      write(unit_, '(A11,9X,A9,13X,A9)') '# Frequency', 'Real(mHT)',
+     &     'Imag(mHT)'
+
+      do point = 1, number_of_points
+         absorption_tabulated(point) = profile(nu0,GammaD,Gamma0_He,
+     &      Gamma2_He,Delta0_He,Delta2_He,NuOptRe_He,NuOptIm_He,
+     &      nu_tabulated(point),Ylm,Xlm,alpha_He,
+     &      not_calculate_dispersion)
+         dispersion_tabulated(point) = profile(nu0,GammaD,Gamma0_He,
+     &      Gamma2_He,Delta0_He,Delta2_He,NuOptRe_He,NuOptIm_He,
+     &      nu_tabulated(point),Ylm,Xlm,alpha_He,calculate_dispersion)
+      write(unit_, '(F15.8, 2F22.15)') nu_tabulated(point),
+     &   absorption_tabulated(point), dispersion_tabulated(point)
+      end do
+
+      close(unit_)
+      write(*,104)
+ 104  format('The result has been saved to mHT_profile_H2He.txt')
+
+      end program example_profiles

--- a/fortran77/src/constants.inc
+++ b/fortran77/src/constants.inc
@@ -1,0 +1,8 @@
+      real*8 inverse_sqrt_pi, pi, square_root_pi, sqrt_ln2,
+     &       numerical_zero, numerical_infty
+      parameter (inverse_sqrt_pi = 0.5641895835477563d0, 
+     &          pi = 3.141592653589793d0, 
+     &          square_root_pi = 1.772453850905516d0, 
+     &          sqrt_ln2 = 0.8325546111576977d0,
+     &          numerical_zero = 1d-15,
+     &          numerical_infty = 4d3)

--- a/fortran77/src/cpf.f
+++ b/fortran77/src/cpf.f
@@ -1,0 +1,109 @@
+c----------------------------------------------------------------------
+      function cpf_accurate(x, y)
+c----------------------------------------------------------------------
+c Computes the complex probability function using a rational
+c series with 42 terms. Assumes Im(z) > 0 or Im(z) = 0.
+c Input Parameters:
+c   x : Real part of input complex parameter
+c   y : Imaginary part of input complex parameter
+c Output:
+c   Complex probability function
+c----------------------------------------------------------------------
+      include 'constants.inc'
+      real*8 x, y
+      real*8 weidemann_constant_42, fft_constant_terms(37)
+      integer i, number_of_fft_terms
+      complex*16 cpf_accurate, z, z_ratio, cpf_z
+
+      parameter (number_of_fft_terms = 37)
+      parameter (weidemann_constant_42 = 5.449631621480024d0)
+
+      data fft_constant_terms / -3.129493160727961d-14,
+     &  -1.188364999909099d-14,  1.951777029849348d-13,
+     &   1.790586243645278d-13, -1.184560208678836d-12,
+     &  -2.069163661083667d-12,  6.430136110306704d-12,
+     &   2.063579921011804d-11, -2.392389527320517d-11,
+     &  -1.799169607159564d-10, -6.353807951660892d-11,
+     &   1.282896083944607d-9,   2.636162411919059d-9,
+     &  -5.468780625369738d-9,  -3.294773119114329d-8,
+     &  -2.752070035718561d-8,   2.206733163926054d-7,
+     &   8.511689670641750d-7,   4.936972061734341d-7,
+     &  -6.617492208403963d-6,  -2.914574364851397d-5,
+     &  -4.816473680511106d-5,   1.044072210002090d-4,
+     &   1.070131083157417d-3,   4.631075611097791d-3,
+     &   1.480296368764821d-2,   3.922970169744468d-2,
+     &   9.038744880336540d-2,   1.857036333535562d-1,
+     &   3.455278077566057d-1,   5.882708203344523d-1,
+     &   9.230959991941070d-1,   1.342044484596932d0,
+     &   1.814714451499866d0,    2.288734169675538d0,
+     &   2.697763665856064d0,    2.975931371735470d0 /
+
+      z = cmplx(-y, x)
+      z_ratio = (weidemann_constant_42 + z)/(weidemann_constant_42 - z)
+      cpf_z = cmplx(0.0d0, 0.0d0)
+
+      do i = 1, number_of_fft_terms
+         cpf_z = cpf_z + fft_constant_terms(i) * z_ratio** 
+     &             (number_of_fft_terms - i)
+      end do
+      cpf_accurate = 2.0d0 * cpf_z  
+     &             / (weidemann_constant_42 - z)**2.0d0
+     &             + inverse_sqrt_pi / (weidemann_constant_42 - z)
+      end function cpf_accurate
+c----------------------------------------------------------------------
+      function cpf_fast(x, y)
+c----------------------------------------------------------------------
+c Computes the complex probability function using Humlicek's algorithm 
+c and rational series with 24 terms.
+c Input Parameters:
+c   x : Real part of input complex parameter
+c   y : Imaginary part of input complex parameter
+c Output:
+c   Complex probability function
+c----------------------------------------------------------------------
+      include 'constants.inc'
+      real*8 x, y
+      real*8 hum1_threshold, weidemann_constant_24,
+     &           fft_constant_terms(24)
+      integer i, number_of_fft_terms
+      complex*16 cpf_fast, z, z_ratio, cpf_z, t
+
+      parameter (number_of_fft_terms = 24)
+      parameter (hum1_threshold = 15.0d0)
+      parameter (weidemann_constant_24 = 4.119534287814236d0)
+
+      data fft_constant_terms / -1.513747622620502d-10,
+     &   4.904820407381768d-9,   1.331045329581992d-9,
+     &  -3.008282344381996d-8,  -1.912225887484805d-8,
+     &   1.873834346505099d-7,   2.568264135399530d-7,
+     &  -1.085647579417637d-6,  -3.038893184366094d-6,
+     &   4.139461724429617d-6,   3.047106608295325d-5,
+     &   2.433141546207148d-5,  -2.074843151143828d-4,
+     &  -7.816642995626165d-4,  -4.936426901286291d-4,
+     &   6.215006362949147d-3,   3.372336685531603d-2,
+     &   1.083872348456673d-1,   2.654963959880772d-1,
+     &   5.361139535729116d-1,   9.257087138588670d-1,
+     &   1.394819673379119d0,    1.856286499205540d0,
+     &   2.197858936531542d0 /
+
+      if (abs(x) + y > hum1_threshold) then
+         t = cmplx(y, -x)
+         cpf_z = inverse_sqrt_pi * t / (0.5d0 + t**2.0d0)
+      else
+         z = cmplx(-y, x)
+         z_ratio = (weidemann_constant_24 + z)
+     &             / (weidemann_constant_24 - z)
+         cpf_z = cmplx(0.0d0, 0.0d0)
+
+         do i = 1, number_of_fft_terms
+            cpf_z = cpf_z + fft_constant_terms(i) * z_ratio**
+     &                (number_of_fft_terms - i)
+         end do
+
+         cpf_z = 2.0d0 * cpf_z
+     &         / (weidemann_constant_24 - z)**2.0d0
+     &         + inverse_sqrt_pi / (weidemann_constant_24 - z)
+      endif
+
+      cpf_fast = cpf_z
+      end function cpf_fast

--- a/fortran77/src/profile.f
+++ b/fortran77/src/profile.f
@@ -1,0 +1,150 @@
+      function beta(GammaD, NuOptRe, alpha)
+c-----------------------------------------------------------------------
+c "beta": Beta-Correction  
+c Subroutine to compute beta-correction used for hard-collision
+c based line-shape profiles to correct NuOptRe value.
+c Applicable up to alpha = 5.0; for higher alpha
+c values correction neglected. 
+c Source: 10.1016/j.jqsrt.2019.106784
+c
+c Input/Output Parameters of Routine (Arguments or Common)
+c-----------------------------------------------------------------------
+c GammaD   : Doppler HWHM in cm-1 (Input) 
+c NuOptRe  : Real part of the Dicke parameter in cm-1 (Input).
+c alpha    : Mass ratio in the molecule. Applicable up to alpha=5.
+c
+c The function provides one output:
+c-----------------------------------------------------------------------
+c (1): Value of the beta correction 
+c-----------------------------------------------------------------------
+      real*8 :: GammaD, NuOptRe, alpha, beta
+c-----------------------------------------------------------------------
+c the mass ratio for which the beta correction becomes negligible
+c-----------------------------------------------------------------------
+      parameter (alpha_max = 5.0d0)
+c-----------------------------------------------------------------------
+      real*8 :: a, b, c, d
+c-----------------------------------------------------------------------
+      if (alpha < alpha_max) then
+c-----------------------------------------------------------------------
+         a =  0.0534d0 + 0.1585d0 * exp(-0.4510d0 * alpha)
+         b =  1.9595d0 - 0.1258d0 * alpha + 0.0056d0 * alpha**2.0d0
+     &     + 0.0050d0 * alpha**3.0d0
+         c = -0.0546d0 + 0.0672d0 * alpha - 0.0125d0 * alpha**2.0d0
+     &     + 0.0003d0 * alpha**3.0d0
+         d =  0.9466d0 - 0.1585d0 * exp(-0.4510d0 * alpha)
+         beta = a * tanh(b * log10(0.5d0 * NuOptRe / GammaD)+c) + d
+c-----------------------------------------------------------------------
+      else
+c-----------------------------------------------------------------------
+         beta = 1.0d0
+c-----------------------------------------------------------------------
+      endif
+c-----------------------------------------------------------------------
+      end function beta
+c-----------------------------------------------------------------------
+      function profile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,NuOptRe,
+     &   NuOptIm,nu,Ylm,Xlm,alpha,calculate_dispersion)
+c-----------------------------------------------------------------------
+c "PROFILE_mHT": modified Hartman Tran profile
+c Subroutine to compute the complex normalized spectral shape of an 
+c isolated line by the mHT model
+c
+c Input/Output Parameters of Routine (Arguments or Common)
+c-----------------------------------------------------------------------
+c nu0       : Unperturbed line position in cm-1 (Input).
+c GammaD    : Doppler HWHM in cm-1 (Input)
+c Gamma0    : Speed-averaged line-width in cm-1 (Input).       
+c Gamma2    : Speed dependence of the line-width in cm-1 (Input).
+c Delta0    : Speed-averaged line-shift in cm-1 (Input).
+c Delta2    : Speed dependence of the line-shift in cm-1 (Input)   
+c NuOptRe   : Real part of the Dicke parameter in cm-1 (Input).
+c NuOptIm   : Imaginary part of the Dicke parameter in cm-1 (Input).    
+c nu        : Current WaveNumber of the Computation in cm-1 (Input).
+c Ylm       : Imaginary part of the 1st order (Rosenkranz) line
+c             mixing coefficients, dimensionless (Input).
+c Xlm       : Real part of the 1st order (Rosenkranz) line mixing
+c             coefficients, dimensionless (Input).
+c alpha     : Mass ratio in the molecule for calculating
+c             beta-correction (Input). Applicable up
+c             to alpha=5.
+c calculate_dispersion_opt : (Input) false by default:
+c             "mHT_profile" returns the real part of the mHT
+c             profile (absorption). If true, "mHT_profile" returns
+c             the imaginary part of the profile (dispersion).
+c
+c The function provides one output:
+c-----------------------------------------------------------------------
+c (1) the normalized spectral shape (cm):
+c     - if "calculate_dispersion" is false (default), the function
+c       returns the absorption profile.
+c     - if "calculate_dispersion" is true, the function returns
+c       the dispersion profile.
+c-----------------------------------------------------------------------
+      include 'constants.inc'
+c-----------------------------------------------------------------------
+      real*8 :: nu0, GammaD, Gamma0, Gamma2, Delta0, Delta2, NuOptRe,
+     &   NuOptIm, nu, Ylm, Xlm, alpha, profile
+      logical :: calculate_dispersion
+      !----------------------------------------------------------------!
+      parameter (small_threshold = 3.0d-8)
+      !----------------------------------------------------------------!
+      complex*16 :: calculated_profile, cpf_accurate
+      real*8 :: nuD, nuR
+      complex*16 :: c2, c0, LM, X, Y, csqY, z1, z2, w1, w2, wX, A,
+     &   X_sqrt, z, w
+c-----------------------------------------------------------------------
+      nuD = GammaD / sqrt_ln2
+      nuR = NuOptRe*beta(GammaD,NuOptRe,alpha)
+      c2  = cmplx(Gamma2, Delta2)
+      c0  = cmplx(Gamma0, Delta0) - 1.5d0*c2 + nuR
+     &    + cmplx(0.0d0, NuOptIm)
+      LM  = cmplx(1.0d0 + Xlm, Ylm)
+c-----------------------------------------------------------------------
+      if ( abs(c2) > numerical_zero ) then
+c-----------------------------------------------------------------------
+         X    = (cmplx(0.0d0, nu0-nu) + c0) / c2
+         Y    = 0.25d0*(nuD/c2)**2.0d0
+         csqY = 0.5d0*nuD*cmplx(Gamma2, -Delta2)
+     &        /(Gamma2**2.0d0 + Delta2**2.0d0)
+         if ( abs( Y )  > abs( X  ) * numerical_zero ) then
+c-----------------------------------------------------------------------
+            z2 = (X+Y)**0.5d0 + csqY
+            if  ( abs(X)  > abs(Y)  * small_threshold ) then
+               z1 = z2 - 2.0d0 * csqY
+            else
+               z1 = (cmplx(0.0d0, nu0-nu) + c0) / nuD    
+            endif
+            w1 = cpf_accurate(-aimag(z1),real(z1))
+            w2 = cpf_accurate(-aimag(z2),real(z2))
+            A  = square_root_pi/nuD*(w1-w2)
+c-----------------------------------------------------------------------
+         else
+c-----------------------------------------------------------------------
+            X_sqrt = (X)**0.5d0
+            if (  abs(X) < numerical_infty ) then
+               wX = cpf_accurate(-aimag(X_sqrt),real(X_sqrt))
+               A  = 2.0d0*(1.0d0 - square_root_pi*X_sqrt*wX)/c2
+            else
+               A  = (1.0d0/X - 1.5d0/X**2.0d0)/c2
+            endif
+c-----------------------------------------------------------------------
+         endif
+c-----------------------------------------------------------------------
+      else
+c-----------------------------------------------------------------------
+         z = (cmplx(0.0d0, nu0-nu) + c0) / nuD
+         w = cpf_accurate(-aimag(z),real(z))
+         A = w*square_root_pi/nuD
+c-----------------------------------------------------------------------
+      endif
+c-----------------------------------------------------------------------
+      calculated_profile  = LM/pi*A/(1-(nuR + cmplx(0.0d0, NuOptIm))*A)
+c-----------------------------------------------------------------------
+      if (calculate_dispersion) then
+         profile = aimag(calculated_profile)
+      else
+         profile = real(calculated_profile)
+      endif
+c-----------------------------------------------------------------------
+      end function profile


### PR DESCRIPTION
See Issue #52.

Major modification: all arguments of the `profile` function must be passed explicitly, since Fortran77 does not support optional arguments.