### PR TITLE
Fortran minor corrections cpf fast cpf accurate jan2025

### DIFF
--- a/fortran/example_absorption.f90
+++ b/fortran/example_absorption.f90
@@ -2,7 +2,7 @@ program example_absorption
 
 ! Example parameters of the S(1) 3-0 line of H2 perturbed by He (reference: 10.1103/PhysRevA.101.052705)
    use, intrinsic :: iso_fortran_env, only: int32, dp => real64
-   use spectral_module, only: profile
+   use spectral_module, only: mHTprofile
    implicit none
    real(dp) :: mHT
    real(dp) :: nu0 = 112265.5949_dp ! Unperturbed line position in cm-1.
@@ -15,7 +15,7 @@ program example_absorption
    real(dp) :: NuOptIm = -17.5e-3_dp ! Imaginary part of the Dicke parameter in cm-1.
    real(dp) :: nu ! Current wavenumber of the computation in cm-1.
    nu  = nu0 + 1.0_dp
-   mHT = profile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,NuOptRe,NuOptIm,nu)
+   mHT = mHTprofile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,NuOptRe,NuOptIm,nu)
    
    write(*,'(A, F22.15)') "The output of the mHT function (absorption,"&
       // " He-perturbed S(1) 3-0 line in H2):", mHT

--- a/fortran/example_dispersion.f90
+++ b/fortran/example_dispersion.f90
@@ -2,7 +2,7 @@ program example_dispersion
 
 ! Example parameters of the S(1) 3-0 line of H2 perturbed by He (reference: 10.1103/PhysRevA.101.052705)
    use, intrinsic :: iso_fortran_env, only: int32, dp => real64
-   use spectral_module, only: profile
+   use spectral_module, only: mHTprofile
    implicit none
    real(dp) :: mHT
    real(dp) :: nu0 = 112265.5949_dp ! Unperturbed line position in cm-1.
@@ -16,7 +16,7 @@ program example_dispersion
    real(dp) :: nu ! Current wavenumber of the computation in cm-1.
    logical :: calculate_dispersion = .true. ! The mHT function will return the dispersion profile.
    nu  = nu0 + 1.0_dp
-   mHT = profile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,NuOptRe,       &
+   mHT = mHTprofile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,NuOptRe,    &
       NuOptIm,nu,calculate_dispersion_opt=calculate_dispersion)
    
    write(*,'(A, F22.15)') "The output of the mHT function (dispersion,"&

--- a/fortran/example_mHT_optional_parameters.f90
+++ b/fortran/example_mHT_optional_parameters.f90
@@ -1,6 +1,6 @@
 program example_mHT_optional_parameters
    use, intrinsic :: iso_fortran_env, only: int32, dp => real64
-   use spectral_module, only: profile
+   use spectral_module, only: mHTprofile
    implicit none
    real(dp) :: absorption, dispersion
 ! Example parameters of the S(1) 3-0 line of H2 perturbed by He (reference: 10.1103/PhysRevA.101.052705)
@@ -19,22 +19,22 @@ program example_mHT_optional_parameters
    logical  :: calculate_dispersion  ! The mHT function will return either the dispersion or absorption profile.
    
    nu  = nu0 + 1.0_dp
-   absorption = profile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,NuOptRe,&
-      NuOptIm,nu)
+   absorption = mHTprofile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,     &
+      NuOptRe,NuOptIm,nu)
    calculate_dispersion = .true.
-   dispersion = profile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,NuOptRe,&
-      NuOptIm,nu,calculate_dispersion_opt=calculate_dispersion)
+   dispersion = mHTprofile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,     &
+      NuOptRe,NuOptIm,nu,calculate_dispersion_opt=calculate_dispersion)
    write(*, '(A, 25X, 2F22.15)') "The output of the mHT function "     &
       // "(He-perturbed S(1) 3-0 line in H2):", absorption, dispersion
 ! optional parameters
    Ylm = 1.0e-3_dp
    Xlm = 0.5e-3_dp
-   alpha = 20.0_dp
+   alpha = 2.0_dp
 
-   absorption = profile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,NuOptRe,&
-      NuOptIm,nu,Ylm,Xlm,alpha)
-   dispersion = profile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,NuOptRe,&
-      NuOptIm,nu,Ylm,Xlm,alpha,calculate_dispersion)
+   absorption = mHTprofile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,     &
+      NuOptRe,NuOptIm,nu,Ylm,Xlm,alpha)
+   dispersion = mHTprofile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,     &
+      NuOptRe,NuOptIm,nu,Ylm,Xlm,alpha,calculate_dispersion)
 
    write(*, '(A, 2F22.15)') "The output of the mHT function with "     &
       // "optional parameters (He-perturbed S(1) 3-0 line in H2):",    &

--- a/fortran/example_profiles.f90
+++ b/fortran/example_profiles.f90
@@ -1,6 +1,6 @@
 program example_profiles
    use, intrinsic :: iso_fortran_env, only: int32, dp => real64
-   use spectral_module, only: profile
+   use spectral_module, only: mHTprofile
    implicit none
    real(dp), allocatable :: nu_tabulated(:) ! Frequency grid in cm-1.
    real(dp), allocatable :: absorption_tabulated(:), dispersion_tabulated(:)
@@ -54,10 +54,10 @@ program example_profiles
    
    do point = 1, 1001
       nu_tabulated(point) = nu0 - 5*GammaD + (point-1) * nu_step
-      absorption_tabulated(point) = profile(nu0,GammaD,Gamma0_Ar,      &
+      absorption_tabulated(point) = mHTprofile(nu0,GammaD,Gamma0_Ar,   &
          Gamma2_Ar,Delta0_Ar,Delta2_Ar,NuOptRe_Ar,NuOptIm_Ar,          &
          nu_tabulated(point),Ylm,Xlm,alpha_Ar)
-      dispersion_tabulated(point) = profile(nu0,GammaD,Gamma0_Ar,      &
+      dispersion_tabulated(point) = mHTprofile(nu0,GammaD,Gamma0_Ar,   &
          Gamma2_Ar,Delta0_Ar,Delta2_Ar,NuOptRe_Ar,NuOptIm_Ar,          &
          nu_tabulated(point),Ylm,Xlm,alpha_Ar,calculate_dispersion_opt=&
          calculate_dispersion)
@@ -86,10 +86,10 @@ program example_profiles
    write(unit_,'(A)')'# Frequency         Real(mHT)             Imag(mHT)'
 
    do point = 1, 1001
-      absorption_tabulated(point) = profile(nu0,GammaD,Gamma0_He,      &
+      absorption_tabulated(point) = mHTprofile(nu0,GammaD,Gamma0_He,   &
          Gamma2_He,Delta0_He,Delta2_He,NuOptRe_He,NuOptIm_He,          &
          nu_tabulated(point),Ylm,Xlm,alpha_He)
-      dispersion_tabulated(point) = profile(nu0,GammaD,Gamma0_He,      &
+      dispersion_tabulated(point) = mHTprofile(nu0,GammaD,Gamma0_He,   &
          Gamma2_He,Delta0_He,Delta2_He,NuOptRe_He,NuOptIm_He,          &
          nu_tabulated(point),Ylm,Xlm,alpha_He,calculate_dispersion)
       write(unit_, '(F15.8, 2F22.15)') nu_tabulated(point),            &

--- a/fortran/mHT/cpf.f90
+++ b/fortran/mHT/cpf.f90
@@ -86,8 +86,7 @@ module cpf_module
          * z_ratio) * z_ratio) * z_ratio) * z_ratio) * z_ratio)        &
          * z_ratio) * z_ratio) * z_ratio) * z_ratio) * z_ratio)        &
          * z_ratio) * z_ratio) * z_ratio) * z_ratio) * z_ratio)        &
-         * z_ratio) * z_ratio) * z_ratio
-      
+         * z_ratio) * z_ratio) * z_ratio    
       cpf_z = ( 2.0_dp * cpf_z / (weidemann_constant_42 - z)           &
          + inverse_sqrt_pi) / (weidemann_constant_42 - z)
       !----------------------------------------------------------------!
@@ -140,7 +139,6 @@ module cpf_module
          !-------------------------------------------------------------!
          z       = dcmplx(-y, x)
          z_ratio = (weidemann_constant_24 + z) / (weidemann_constant_24 - z)
-
          cpf_z   =                                                     &
              fft_constant_terms(24) + (fft_constant_terms(23) +        &
             (fft_constant_terms(22) + (fft_constant_terms(21) +        &
@@ -159,7 +157,6 @@ module cpf_module
             * z_ratio) * z_ratio) * z_ratio) * z_ratio) * z_ratio)     &
             * z_ratio) * z_ratio) * z_ratio) * z_ratio) * z_ratio)     &
             * z_ratio) * z_ratio
-
          cpf_z = ( 2.0_dp * cpf_z / (weidemann_constant_24 - z)        &
             + inverse_sqrt_pi ) / (weidemann_constant_24 - z)
          !-------------------------------------------------------------!

--- a/fortran/mHT/cpf.f90
+++ b/fortran/mHT/cpf.f90
@@ -60,13 +60,36 @@ module cpf_module
       !----------------------------------------------------------------!
       z       = dcmplx(-y, x)
       z_ratio = (weidemann_constant_42 + z) / (weidemann_constant_42 - z)
-      cpf_z   = (0.0_dp, 0.0_dp)
-      do i = 1, number_of_fft_terms
-         cpf_z = cpf_z + fft_constant_terms(i)                         &
-            * z_ratio**(number_of_fft_terms - i)
-      end do
-      cpf_z = 2.0_dp * cpf_z / (weidemann_constant_42 - z)**2.0_dp     &
-         + inverse_sqrt_pi / (weidemann_constant_42 - z)
+      cpf_z   =                                                        &
+          fft_constant_terms(37) + (fft_constant_terms(36) +           &
+         (fft_constant_terms(35) + (fft_constant_terms(34) +           &
+         (fft_constant_terms(33) + (fft_constant_terms(32) +           &
+         (fft_constant_terms(31) + (fft_constant_terms(30) +           &
+         (fft_constant_terms(29) + (fft_constant_terms(28) +           &
+         (fft_constant_terms(27) + (fft_constant_terms(26) +           &
+         (fft_constant_terms(25) + (fft_constant_terms(24) +           &
+         (fft_constant_terms(23) + (fft_constant_terms(22) +           &
+         (fft_constant_terms(21) + (fft_constant_terms(20) +           &
+         (fft_constant_terms(19) + (fft_constant_terms(18) +           &
+         (fft_constant_terms(17) + (fft_constant_terms(16) +           &
+         (fft_constant_terms(15) + (fft_constant_terms(14) +           &
+         (fft_constant_terms(13) + (fft_constant_terms(12) +           &
+         (fft_constant_terms(11) + (fft_constant_terms(10) +           &
+         (fft_constant_terms(9)  + (fft_constant_terms(8)  +           &
+         (fft_constant_terms(7)  + (fft_constant_terms(6)  +           &
+         (fft_constant_terms(5)  + (fft_constant_terms(4)  +           &
+         (fft_constant_terms(3)  + (fft_constant_terms(2)  +           &
+         fft_constant_terms(1) * z_ratio) * z_ratio) * z_ratio)        &
+         * z_ratio) * z_ratio) * z_ratio) * z_ratio) * z_ratio)        &
+         * z_ratio) * z_ratio) * z_ratio) * z_ratio) * z_ratio)        &
+         * z_ratio) * z_ratio) * z_ratio) * z_ratio) * z_ratio)        &
+         * z_ratio) * z_ratio) * z_ratio) * z_ratio) * z_ratio)        &
+         * z_ratio) * z_ratio) * z_ratio) * z_ratio) * z_ratio)        &
+         * z_ratio) * z_ratio) * z_ratio) * z_ratio) * z_ratio)        &
+         * z_ratio) * z_ratio) * z_ratio
+      
+      cpf_z = ( 2.0_dp * cpf_z / (weidemann_constant_42 - z)           &
+         + inverse_sqrt_pi) / (weidemann_constant_42 - z)
       !----------------------------------------------------------------!
    end function cpf_accurate
 !----------------------------------------------------------------------!
@@ -117,13 +140,28 @@ module cpf_module
          !-------------------------------------------------------------!
          z       = dcmplx(-y, x)
          z_ratio = (weidemann_constant_24 + z) / (weidemann_constant_24 - z)
-         cpf_z   = (0.0_dp, 0.0_dp)
-         do i = 1, number_of_fft_terms
-            cpf_z = cpf_z + fft_constant_terms(i)                      &
-               * z_ratio**(number_of_fft_terms - i)
-         end do
-         cpf_z = 2.0_dp * cpf_z / (weidemann_constant_24 - z)**2.0_dp  &
-            + inverse_sqrt_pi / (weidemann_constant_24 - z)
+
+         cpf_z   =                                                     &
+             fft_constant_terms(24) + (fft_constant_terms(23) +        &
+            (fft_constant_terms(22) + (fft_constant_terms(21) +        &
+            (fft_constant_terms(20) + (fft_constant_terms(19) +        &
+            (fft_constant_terms(18) + (fft_constant_terms(17) +        &
+            (fft_constant_terms(16) + (fft_constant_terms(15) +        &
+            (fft_constant_terms(14) + (fft_constant_terms(13) +        &
+            (fft_constant_terms(12) + (fft_constant_terms(11) +        &
+            (fft_constant_terms(10) + (fft_constant_terms(9)  +        &
+            (fft_constant_terms(8)  + (fft_constant_terms(7)  +        &
+            (fft_constant_terms(6)  + (fft_constant_terms(5)  +        &
+            (fft_constant_terms(4)  + (fft_constant_terms(3)  +        &
+            (fft_constant_terms(2)  + fft_constant_terms(1) * z_ratio) &
+            * z_ratio) * z_ratio) * z_ratio) * z_ratio) * z_ratio)     &
+            * z_ratio) * z_ratio) * z_ratio) * z_ratio) * z_ratio)     &
+            * z_ratio) * z_ratio) * z_ratio) * z_ratio) * z_ratio)     &
+            * z_ratio) * z_ratio) * z_ratio) * z_ratio) * z_ratio)     &
+            * z_ratio) * z_ratio
+
+         cpf_z = ( 2.0_dp * cpf_z / (weidemann_constant_24 - z)        &
+            + inverse_sqrt_pi ) / (weidemann_constant_24 - z)
          !-------------------------------------------------------------!
       endif
       !----------------------------------------------------------------!

--- a/fortran/mHT/profile.f90
+++ b/fortran/mHT/profile.f90
@@ -64,9 +64,8 @@ module spectral_module
       !----------------------------------------------------------------!
    end function beta
 !----------------------------------------------------------------------!
-   function profile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,NuOptRe,    &
-      NuOptIm,nu,Ylm_opt,Xlm_opt,alpha_opt,calculate_dispersion_opt)   &
-      result(mHT_profile)
+   function mHTprofile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,NuOptRe, &
+      NuOptIm,nu,Ylm_opt,Xlm_opt,alpha_opt,calculate_dispersion_opt)
       !----------------------------------------------------------------!
       ! "PROFILE_mHT": modified Hartmann-Tran profile
       ! Subroutine to compute the complex normalized spectral shape of an 
@@ -91,8 +90,8 @@ module spectral_module
       !             beta-correction (Input, optional). Applicable up
       !             to alpha=5.
       ! calculate_dispersion_opt : (Input, optional) false by default:
-      !             "mHT_profile" returns the real part of the mHT
-      !             profile (absorption). If true, "mHT_profile" returns
+      !             "mHTprofile" returns the real part of the mHT
+      !             profile (absorption). If true, "mHTprofile" returns
       !             the imaginary part of the profile (dispersion).
       !
       ! The function provides one output:
@@ -107,7 +106,7 @@ module spectral_module
          Delta2, NuOptRe, NuOptIm, nu
       real(dp), intent(in), optional :: Ylm_opt, Xlm_opt, alpha_opt
       logical, intent(in), optional :: calculate_dispersion_opt
-      real(dp) :: mHT_profile
+      real(dp) :: mHTprofile
       !----------------------------------------------------------------!
       real(dp), parameter :: small_threshold = 3e-8_dp
       !----------------------------------------------------------------!
@@ -190,11 +189,11 @@ module spectral_module
       calculated_profile  = LM/pi*A/(1-(nuR + cmplx(0.0_dp, NuOptIm, kind=dp))*A)
       !----------------------------------------------------------------!
       if (calculate_dispersion) then
-         mHT_profile = dimag(calculated_profile)
+         mHTprofile = dimag(calculated_profile)
       else
-         mHT_profile = dreal(calculated_profile)
+         mHTprofile = dreal(calculated_profile)
       endif
       !----------------------------------------------------------------!
-   end function profile 
+   end function mHTprofile 
 
 end module spectral_module

--- a/fortran77/example_absorption.f
+++ b/fortran77/example_absorption.f
@@ -1,7 +1,7 @@
       program example_absorption
 c Example parameters of the S(1) 3-0 line of H2 perturbed by He (reference: 10.1103/PhysRevA.101.052705)
       implicit none
-      double precision :: mHT, profile
+      double precision :: mHT, mHTprofile
       double precision :: nu0 = 112265.5949d0 ! Unperturbed line position in cm-1.
       double precision :: GammaD = 35.1d-3 ! Doppler broadening in cm-1.
       double precision :: Gamma0 = 11.7d-3 ! Speed-averaged line-width in cm-1.
@@ -17,8 +17,8 @@ c Example parameters of the S(1) 3-0 line of H2 perturbed by He (reference: 10.1
       logical :: calculate_dispersion=.false. ! Only the absorption profile will be calculated
 
       nu  = nu0 + 1.0d0
-      mHT = profile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,NuOptRe,
-     &              NuOptIm,nu,Ylm,Xlm,alpha,calculate_dispersion)
+      mHT = mHTprofile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,NuOptRe,
+     &                 NuOptIm,nu,Ylm,Xlm,alpha,calculate_dispersion)
    
       write(*,101) mHT
  101  format('The output of the mHT function (absorption, He-perturbed',

--- a/fortran77/example_dispersion.f
+++ b/fortran77/example_dispersion.f
@@ -1,7 +1,7 @@
       program example_dispersion
 c Example parameters of the S(1) 3-0 line of H2 perturbed by He (reference: 10.1103/PhysRevA.101.052705)
       implicit none
-      double precision :: mHT, profile
+      double precision :: mHT, mHTprofile
       double precision :: nu0 = 112265.5949d0 ! Unperturbed line position in cm-1.
       double precision :: GammaD = 35.1d-3 ! Doppler broadening in cm-1.
       double precision :: Gamma0 = 11.7d-3 ! Speed-averaged line-width in cm-1.
@@ -17,8 +17,8 @@ c Example parameters of the S(1) 3-0 line of H2 perturbed by He (reference: 10.1
       logical :: calculate_dispersion = .true. ! The mHT function will return the dispersion profile.
 
       nu  = nu0 + 1.0d0
-      mHT = profile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,NuOptRe,
-     &      NuOptIm,nu,Ylm,Xlm,alpha,calculate_dispersion)
+      mHT = mHTprofile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,NuOptRe,
+     &                 NuOptIm,nu,Ylm,Xlm,alpha,calculate_dispersion)
    
       write(*,101) mHT
  101  format('The output of the mHT function (dispersion, He-perturbed',

--- a/fortran77/example_mHT_optional_parameters.f
+++ b/fortran77/example_mHT_optional_parameters.f
@@ -1,7 +1,7 @@
       program example_mHT_optional_parameters
 c Example parameters of the S(1) 3-0 line of H2 perturbed by He (reference: 10.1103/PhysRevA.101.052705)
       implicit none
-      double precision :: absorption,dispersion, profile
+      double precision :: absorption,dispersion, mHTprofile
       double precision :: nu0 = 112265.5949d0 ! Unperturbed line position in cm-1.
       double precision :: GammaD = 35.1d-3 ! Doppler broadening in cm-1.
       double precision :: Gamma0 = 11.7d-3 ! Speed-averaged line-width in cm-1.
@@ -17,10 +17,10 @@ c Example parameters of the S(1) 3-0 line of H2 perturbed by He (reference: 10.1
       logical :: calculate_dispersion=.false. ! Only the absorption profile will be calculated
    
       nu  = nu0 + 1d0
-      absorption = profile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,
+      absorption = mHTprofile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,
      &            NuOptRe,NuOptIm,nu,Ylm,Xlm,alpha,calculate_dispersion)
       calculate_dispersion = .true.
-      dispersion = profile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,
+      dispersion = mHTprofile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,
      &            NuOptRe,NuOptIm,nu,Ylm,Xlm,alpha,calculate_dispersion)
       write(*, 101) absorption, dispersion
  101  format('The output of the mHT function (He-perturbed S(1)',
@@ -28,14 +28,14 @@ c Example parameters of the S(1) 3-0 line of H2 perturbed by He (reference: 10.1
 c optional parameters
       Ylm = 1.0d-3
       Xlm = 0.5d-3
-      alpha = 20.0d0
+      alpha = 2.0d0
       calculate_dispersion = .false.
       
-      absorption = profile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,
+      absorption = mHTprofile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,
      &            NuOptRe,NuOptIm,nu,Ylm,Xlm,alpha,calculate_dispersion)
      
       calculate_dispersion = .true.
-      dispersion = profile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,
+      dispersion = mHTprofile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,
      &            NuOptRe,NuOptIm,nu,Ylm,Xlm,alpha,calculate_dispersion)
 
       write(*, 102) absorption, dispersion

--- a/fortran77/example_profiles.f
+++ b/fortran77/example_profiles.f
@@ -4,7 +4,7 @@
       double precision :: nu_tabulated(number_of_points) ! Frequency grid in cm-1.
       double precision :: absorption_tabulated(number_of_points),
      &          dispersion_tabulated(number_of_points)
-      double precision :: profile
+      double precision :: mHTprofile
       double precision :: nu0 ! Unperturbed line position in cm-1.
       double precision :: GammaD ! Doppler broadening in cm-1.
       double precision :: Gamma0_He, Gamma0_Ar ! Speed-averaged line-width in cm-1.
@@ -51,11 +51,11 @@ c Generate the mHT profile from -5 GammaD to +5 GammaD and save to an external f
    
       do point = 1, number_of_points
          nu_tabulated(point) = nu0 - 5*GammaD + (point-1) * nu_step
-         absorption_tabulated(point) = profile(nu0,GammaD,Gamma0_Ar,
+         absorption_tabulated(point) = mHTprofile(nu0,GammaD,Gamma0_Ar,
      &      Gamma2_Ar,Delta0_Ar,Delta2_Ar,NuOptRe_Ar,NuOptIm_Ar,
      &      nu_tabulated(point),Ylm,Xlm,alpha_Ar,
      &      not_calculate_dispersion)
-         dispersion_tabulated(point) = profile(nu0,GammaD,Gamma0_Ar,
+         dispersion_tabulated(point) = mHTprofile(nu0,GammaD,Gamma0_Ar,
      &      Gamma2_Ar,Delta0_Ar,Delta2_Ar,NuOptRe_Ar,NuOptIm_Ar,
      &      nu_tabulated(point),Ylm,Xlm,alpha_Ar,calculate_dispersion)
 
@@ -87,11 +87,11 @@ c example parameters of the S(1) 3-0 line of H2 perturbed by He (reference 10.11
      &     'Imag(mHT)'
 
       do point = 1, number_of_points
-         absorption_tabulated(point) = profile(nu0,GammaD,Gamma0_He,
+         absorption_tabulated(point) = mHTprofile(nu0,GammaD,Gamma0_He,
      &      Gamma2_He,Delta0_He,Delta2_He,NuOptRe_He,NuOptIm_He,
      &      nu_tabulated(point),Ylm,Xlm,alpha_He,
      &      not_calculate_dispersion)
-         dispersion_tabulated(point) = profile(nu0,GammaD,Gamma0_He,
+         dispersion_tabulated(point) = mHTprofile(nu0,GammaD,Gamma0_He,
      &      Gamma2_He,Delta0_He,Delta2_He,NuOptRe_He,NuOptIm_He,
      &      nu_tabulated(point),Ylm,Xlm,alpha_He,calculate_dispersion)
       write(unit_, '(F15.8, 2F22.15)') nu_tabulated(point),

--- a/fortran77/mHT/cpf.f
+++ b/fortran77/mHT/cpf.f
@@ -40,15 +40,36 @@ c----------------------------------------------------------------------
 
       z = dcmplx(-y, x)
       z_ratio = (weidemann_constant_42 + z)/(weidemann_constant_42 - z)
-      cpf_z = dcmplx(0.0d0, 0.0d0)
-
-      do i = 1, number_of_fft_terms
-         cpf_z = cpf_z + fft_constant_terms(i) * z_ratio** 
-     &             (number_of_fft_terms - i)
-      end do
-      cpf_accurate = 2.0d0 * cpf_z  
-     &             / (weidemann_constant_42 - z)**2.0d0
-     &             + inverse_sqrt_pi / (weidemann_constant_42 - z)
+      cpf_z   =                                                      
+     &    fft_constant_terms(37) + (fft_constant_terms(36) +
+     &   (fft_constant_terms(35) + (fft_constant_terms(34) +
+     &   (fft_constant_terms(33) + (fft_constant_terms(32) +
+     &   (fft_constant_terms(31) + (fft_constant_terms(30) +
+     &   (fft_constant_terms(29) + (fft_constant_terms(28) +
+     &   (fft_constant_terms(27) + (fft_constant_terms(26) +
+     &   (fft_constant_terms(25) + (fft_constant_terms(24) +
+     &   (fft_constant_terms(23) + (fft_constant_terms(22) +
+     &   (fft_constant_terms(21) + (fft_constant_terms(20) +
+     &   (fft_constant_terms(19) + (fft_constant_terms(18) +
+     &   (fft_constant_terms(17) + (fft_constant_terms(16) +
+     &   (fft_constant_terms(15) + (fft_constant_terms(14) +
+     &   (fft_constant_terms(13) + (fft_constant_terms(12) +
+     &   (fft_constant_terms(11) + (fft_constant_terms(10) +
+     &   (fft_constant_terms(9)  + (fft_constant_terms(8)  +
+     &   (fft_constant_terms(7)  + (fft_constant_terms(6)  +
+     &   (fft_constant_terms(5)  + (fft_constant_terms(4)  +
+     &   (fft_constant_terms(3)  + (fft_constant_terms(2)  +
+     &   fft_constant_terms(1) * z_ratio) * z_ratio) * z_ratio)
+     &   * z_ratio) * z_ratio) * z_ratio) * z_ratio) * z_ratio)
+     &   * z_ratio) * z_ratio) * z_ratio) * z_ratio) * z_ratio)
+     &   * z_ratio) * z_ratio) * z_ratio) * z_ratio) * z_ratio)
+     &   * z_ratio) * z_ratio) * z_ratio) * z_ratio) * z_ratio)
+     &   * z_ratio) * z_ratio) * z_ratio) * z_ratio) * z_ratio)
+     &   * z_ratio) * z_ratio) * z_ratio) * z_ratio) * z_ratio)
+     &   * z_ratio) * z_ratio) * z_ratio
+      cpf_accurate = ( 2.0d0 * cpf_z  
+     &             / (weidemann_constant_42 - z)
+     &             + inverse_sqrt_pi ) / (weidemann_constant_42 - z)
       end function cpf_accurate
 c----------------------------------------------------------------------
       function cpf_fast(x, y)
@@ -93,16 +114,27 @@ c----------------------------------------------------------------------
          z = dcmplx(-y, x)
          z_ratio = (weidemann_constant_24 + z)
      &             / (weidemann_constant_24 - z)
-         cpf_z = dcmplx(0.0d0, 0.0d0)
-
-         do i = 1, number_of_fft_terms
-            cpf_z = cpf_z + fft_constant_terms(i) * z_ratio**
-     &                (number_of_fft_terms - i)
-         end do
-
-         cpf_z = 2.0d0 * cpf_z
-     &         / (weidemann_constant_24 - z)**2.0d0
-     &         + inverse_sqrt_pi / (weidemann_constant_24 - z)
+         cpf_z   =
+     &       fft_constant_terms(24) + (fft_constant_terms(23) +
+     &      (fft_constant_terms(22) + (fft_constant_terms(21) +
+     &      (fft_constant_terms(20) + (fft_constant_terms(19) +
+     &      (fft_constant_terms(18) + (fft_constant_terms(17) +
+     &      (fft_constant_terms(16) + (fft_constant_terms(15) +
+     &      (fft_constant_terms(14) + (fft_constant_terms(13) +
+     &      (fft_constant_terms(12) + (fft_constant_terms(11) +
+     &      (fft_constant_terms(10) + (fft_constant_terms(9)  +
+     &      (fft_constant_terms(8)  + (fft_constant_terms(7)  +
+     &      (fft_constant_terms(6)  + (fft_constant_terms(5)  +
+     &      (fft_constant_terms(4)  + (fft_constant_terms(3)  +
+     &      (fft_constant_terms(2)  + fft_constant_terms(1) * z_ratio)
+     &      * z_ratio) * z_ratio) * z_ratio) * z_ratio) * z_ratio)
+     &      * z_ratio) * z_ratio) * z_ratio) * z_ratio) * z_ratio)
+     &      * z_ratio) * z_ratio) * z_ratio) * z_ratio) * z_ratio)
+     &      * z_ratio) * z_ratio) * z_ratio) * z_ratio) * z_ratio)
+     &      * z_ratio) * z_ratio
+         cpf_z = ( 2.0d0 * cpf_z
+     &         / (weidemann_constant_24 - z)
+     &         + inverse_sqrt_pi ) / (weidemann_constant_24 - z)
       endif
 
       cpf_fast = cpf_z

--- a/fortran77/mHT/profile.f
+++ b/fortran77/mHT/profile.f
@@ -43,8 +43,8 @@ c-----------------------------------------------------------------------
 c-----------------------------------------------------------------------
       end function beta
 c-----------------------------------------------------------------------
-      function profile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,NuOptRe,
-     &   NuOptIm,nu,Ylm,Xlm,alpha,calculate_dispersion)
+      function mHTprofile(nu0,GammaD,Gamma0,Gamma2,Delta0,Delta2,
+     &   NuOptRe,NuOptIm,nu,Ylm,Xlm,alpha,calculate_dispersion)
 c-----------------------------------------------------------------------
 c "PROFILE_mHT": modified Hartmann Tran profile
 c Subroutine to compute the complex normalized spectral shape of an 
@@ -84,7 +84,7 @@ c-----------------------------------------------------------------------
       include 'constants.inc'
 c-----------------------------------------------------------------------
       double precision :: nu0, GammaD, Gamma0, Gamma2, Delta0, Delta2,
-     &   NuOptRe, NuOptIm, nu, Ylm, Xlm, alpha, profile
+     &   NuOptRe, NuOptIm, nu, Ylm, Xlm, alpha, mHTprofile
       logical :: calculate_dispersion
       !----------------------------------------------------------------!
       parameter (small_threshold = 3.0d-8)
@@ -142,9 +142,9 @@ c-----------------------------------------------------------------------
       calculated_profile  = LM/pi*A/(1-(nuR + dcmplx(0.0d0, NuOptIm))*A)
 c-----------------------------------------------------------------------
       if (calculate_dispersion) then
-         profile = dimag(calculated_profile)
+         mHTprofile = dimag(calculated_profile)
       else
-         profile = dreal(calculated_profile)
+         mHTprofile = dreal(calculated_profile)
       endif
 c-----------------------------------------------------------------------
-      end function profile
+      end function mHTprofile


### PR DESCRIPTION
- restructured loop over fft terms (F77 and F90)
- modified the final formula for the cpf to avoid additional operation
- `profile` name changed to `mHTprofile`