### PR TITLE
Mathematica dispersion sign

### DIFF
--- a/mathematica/example_mHT_optional_parameters.nb
+++ b/mathematica/example_mHT_optional_parameters.nb
@@ -1,3 +1,21 @@
+(* Content-type: application/vnd.wolfram.mathematica *)
+
+(*** Wolfram Notebook File ***)
+(* http://www.wolfram.com/nb *)
+
+(* CreatedBy='Mathematica 14.0' *)
+
+(*CacheID: 234*)
+(* Internal cache information:
+NotebookFileLineBreakTest
+NotebookFileLineBreakTest
+NotebookDataPosition[       158,          7]
+NotebookDataLength[     11583,        312]
+NotebookOptionsPosition[     11193,        297]
+NotebookOutlinePosition[     11601,        313]
+CellTagsIndexPosition[     11558,        310]
+WindowFrame->Normal*)
+
 (* Beginning of Notebook Content *)
 Notebook[{
 Cell[BoxData[
@@ -190,8 +208,8 @@ parameters:\>\"", "]"}], "\n",
       RowBox[{"{", 
        RowBox[{
        "nu0", ",", "GammaD", ",", "Gamma0", ",", "Gamma2", ",", "Delta0", ",",
-         "Delta2", ",", "NuOptRe", ",", "NuOptIm", ",", "nu", ",", "Xlm", ",",
-         "Ylm", ",", "alpha"}], "}"}], "]"}], "]"}], "]"}], "\n", "\n", 
+         "Delta2", ",", "NuOptRe", ",", "NuOptIm", ",", "nu", ",", "Ylm", ",",
+         "Xlm", ",", "alpha"}], "}"}], "]"}], "]"}], "]"}], "\n", "\n", 
    RowBox[{"(*", " ", 
     RowBox[{
     "Printing", " ", "the", " ", "examples", " ", "for", " ", "dispersion", 
@@ -268,12 +286,14 @@ parameters:\>\"", "]"}], "\n",
       RowBox[{"{", 
        RowBox[{
        "nu0", ",", "GammaD", ",", "Gamma0", ",", "Gamma2", ",", "Delta0", ",",
-         "Delta2", ",", "NuOptRe", ",", "NuOptIm", ",", "nu", ",", "Xlm", ",",
-         "Ylm", ",", "alpha", ",", "True"}], "}"}], "]"}], "]"}], 
+         "Delta2", ",", "NuOptRe", ",", "NuOptIm", ",", "nu", ",", "Ylm", ",",
+         "Xlm", ",", "alpha", ",", "True"}], "}"}], "]"}], "]"}], 
     "]"}]}]}]], "Code",
  InitializationCell->False,
- CellChangeTimes->{{3.9495673198324986`*^9, 3.949567349336569*^9}},
- CellLabel->"In[1]:=",ExpressionUUID->"41f2ab6e-1d4f-0e44-a7dd-be4f834557d8"]
+ CellChangeTimes->{{3.9495673198324986`*^9, 3.949567349336569*^9}, {
+  3.951559440110161*^9, 
+  3.9515594703372593`*^9}},ExpressionUUID->"41f2ab6e-1d4f-0e44-a7dd-\
+be4f834557d8"]
 },
 WindowSize->{1150.8, 594.6},
 WindowMargins->{{-4.8, Automatic}, {Automatic, 0}},
@@ -282,3 +302,19 @@ StyleDefinitions->"Default.nb",
 ExpressionUUID->"1583d74b-be8c-4843-a531-fcb5fed97954"
 ]
 (* End of Notebook Content *)
+
+(* Internal cache information *)
+(*CellTagsOutline
+CellTagsIndex->{}
+*)
+(*CellTagsIndex
+CellTagsIndex->{}
+*)
+(*NotebookFileOutline
+Notebook[{
+Cell[558, 20, 10631, 275, 765, "Code",ExpressionUUID->"41f2ab6e-1d4f-0e44-a7dd-be4f834557d8",
+ InitializationCell->False]
+}
+]
+*)
+

--- a/mathematica/mHT/mHT.m
+++ b/mathematica/mHT/mHT.m
@@ -162,7 +162,7 @@ Block[{nuD = 1.2011224087864498` GammaD,
     nuR = NuOptRe \[Beta][{GammaD,NuOptRe,alpha}];
     c2  = Gamma2 + I Delta2;
     c0  = Gamma0 + I Delta0 - 1.5 c2 + nuR + I NuOptIm;
-    LM  = 1 + Xlm + I Ylm;
+    LM  = 1 + Xlm - I Ylm;
     If[Abs[c2] > (1.0`*^-9) (* Limit where speed dependence impact is lower than numerical noise level *), 
         X    = (I (nu0 - nu) + c0) / c2;
         Y    = 0.25 (nuD / c2)^2;
@@ -184,7 +184,7 @@ Block[{nuD = 1.2011224087864498` GammaD,
         A = w 1.772453850905516` / nuD;
     ];
     ImHT = 0.3183098861837907` LM A / (1 - A (nuR + I NuOptIm));
-    If[Not[disp],Re[ImHT],Im[ImHT]]
+    If[Not[disp],Re[ImHT],-Im[ImHT]]
 ]/;
 NumericQ[nu0] && NumericQ[GammaD] && NumericQ[Gamma0] && NumericQ[Gamma2] && NumericQ[Delta0] && NumericQ[Delta2] &&\
 NumericQ[NuOptRe] && NumericQ[NuOptIm] && NumericQ[Ylm] && NumericQ[Xlm] && NumericQ[alpha]
@@ -229,14 +229,13 @@ Block[{
 CPFVector := ({CPFAccurateVector,CPFFastVector})[[CPFChoice]];
 
 
-(* Modified Hartmann Tran profile function rewritted to allow vector input *)
 mHTProfileVector[{nu0_,GammaD_,Gamma0_,Gamma2_,Delta0_,Delta2_,NuOptRe_,NuOptIm_,nu_,Ylm_:0,Xlm_:0,alpha_:10,disp_:False}] :=
 Block[{nuD = 1.2011224087864498` GammaD,
     nuR,c0,c2,LM,X,Y,csqY,z1,z2,w1,w2,rX,wX,z,w,A,ImHT},
     nuR = NuOptRe \[Beta][{GammaD,NuOptRe,alpha}];
     c2  = Gamma2 + I Delta2;
     c0  = Gamma0 + I Delta0 - 1.5 c2 + nuR + I NuOptIm;
-    LM  = 1 + Xlm + I Ylm;
+    LM  = 1 + Xlm - I Ylm;
     If[Abs[c2] > (1.0`*^-9) (* Limit where speed dependence impact is lower than numerical noise level *), 
         X    = (I (nu0 - nu) + c0) / c2;
         Y    = 0.25 (nuD / c2)^2;
@@ -258,7 +257,7 @@ Block[{nuD = 1.2011224087864498` GammaD,
         A = w 1.772453850905516` / nuD;
     ];
     ImHT = 0.3183098861837907` LM A / (1 - A (nuR + I NuOptIm));
-    If[Not[disp],Re[ImHT],Im[ImHT]]
+    If[Not[disp],Re[ImHT],-Im[ImHT]]
 ]/;
 NumericQ[nu0] && NumericQ[GammaD] && NumericQ[Gamma0] && NumericQ[Gamma2] && NumericQ[Delta0] && NumericQ[Delta2] &&\
 NumericQ[NuOptRe] && NumericQ[NuOptIm] && NumericQ[Ylm] && NumericQ[Xlm] && NumericQ[alpha]


### PR DESCRIPTION
mHT.m > mHTProfile[]: fixed line-mixing sign convention - now negative Ylm and dispersion output with minus.
mHT.m > mHTProfileVector[]: fixed line-mixing sign convention - now negative Ylm and dispersion output with minus.
example_mHT_optional_parameters.nb: fixed Xlm and Ylm changed positions.